### PR TITLE
add benchmark target to maintain models

### DIFF
--- a/models/BenchAll.hs
+++ b/models/BenchAll.hs
@@ -1,0 +1,8 @@
+import qualified BetaBin
+import qualified Dice
+-- import DPmixture -- depends on class Bernoulli
+import qualified Gamma
+-- import HMM -- depends on module Explicit
+
+main :: IO ()
+main = putStrLn "Benchmark not yet implemented."

--- a/monad-bayes.cabal
+++ b/monad-bayes.cabal
@@ -51,13 +51,10 @@ benchmark monad-bayes-bench
   -- maintained. Those modules should also be listed in
   -- `other-modules`.
   main-is:             BenchAll.hs
-  -- List all models we want to watch for changes, including
-  -- those that do not compile. A module listed here is compiled
-  -- only if it is imported from the file in `main-is` as well.
+  -- List all models we want to watch for changes.
+  -- DO NOT list modules that don't compile.
+  -- They make it impossible to run `stack ghci`.
   other-modules:       BetaBin, Dice, Gamma
-                     , HMM
-                     , DPmixture
-
 
 source-repository head
   type:     git

--- a/monad-bayes.cabal
+++ b/monad-bayes.cabal
@@ -36,6 +36,30 @@ test-suite monad-bayes-test
   ghc-options:         -threaded -rtsopts -with-rtsopts=-N
   default-language:    Haskell2010
 
+benchmark monad-bayes-bench
+  type:                exitcode-stdio-1.0
+  hs-source-dirs:      models
+  build-depends:       base
+                     , monad-bayes
+                     , random-fu
+                     , logfloat
+                     , mtl
+                     , math-functions
+                     , hmatrix
+  ghc-options:         -threaded -rtsopts -with-rtsopts=-
+  default-language:    Haskell2010
+  -- Main benchmark file should import all the modules to be
+  -- maintained. Those modules should also be listed in
+  -- `other-modules`.
+  main-is:             BenchAll.hs
+  -- List all models we want to watch for changes, including
+  -- those that do not compile. A module listed here is compiled
+  -- only if it is imported from the file in `main-is` as well.
+  other-modules:       BetaBin, Dice, Gamma
+                     , HMM
+                     , DPmixture
+
+
 source-repository head
   type:     git
   location: https://github.com/adscib/monad-bayes

--- a/monad-bayes.cabal
+++ b/monad-bayes.cabal
@@ -46,7 +46,6 @@ benchmark monad-bayes-bench
                      , mtl
                      , math-functions
                      , hmatrix
-  ghc-options:         -threaded -rtsopts -with-rtsopts=-
   default-language:    Haskell2010
   -- Main benchmark file should import all the modules to be
   -- maintained. Those modules should also be listed in


### PR DESCRIPTION
Proposal: Put all maintained models in the "benchmark" target.
Reason: We want to evaluate inference algorithms on the models later. Evaluation takes time and its result is not binary, so the "benchmark" target fits well.

To compile maintained models, invoke `stack bench`.

Maintained models should _both_ be listed in [monad-bayes.cabal](monad-bayes.cabal) _and_ be imported from [models/BenchAll.hs](models/BenchAll.hs).

The .cabal file triggers rebuild when the listed model files change. Only modules imported from BenchAll.hs are compiled. However, `stack ghci` interprets all models listed in the .cabal file.
