### PR TITLE
Add `Typeable` constraint to categorical distribution

### DIFF
--- a/src/Base.hs
+++ b/src/Base.hs
@@ -8,6 +8,7 @@
 module Base where
 
 import Data.Number.LogFloat
+import Data.Typeable
 import Numeric.SpecFunctions
 import Control.Monad.Trans.Maybe
 import Control.Monad.State.Lazy
@@ -20,7 +21,7 @@ import Primitive
 class Monad m => MonadDist m where
     {-# MINIMAL (categorical, primitive) | (categorical, normal, gamma, beta) #-}
     -- | Categorical distribution, weights need not be normalized.
-    categorical :: [(a,LogFloat)] -> m a
+    categorical :: (Eq a, Typeable a) => [(a,LogFloat)] -> m a
     -- | Normal distribution parameterized by mean and standard deviation.
     normal :: Double -> Double -> m Double
     -- | Gamma distribution parameterized by shape and rate.

--- a/src/Inference.hs
+++ b/src/Inference.hs
@@ -3,6 +3,7 @@ module Inference where
 
 import Data.Either
 import Data.Number.LogFloat
+import Data.Typeable
 import Control.Monad.Trans.Maybe
 import Control.Monad.State.Lazy
 
@@ -24,7 +25,7 @@ importance :: StateT LogFloat Sampler a -> Sampler (a,LogFloat)
 importance d = runStateT d 1
 
 -- | Multiple importance samples with post-processing.
-importance' :: Ord a => Int -> EmpiricalT Sampler a -> Sampler [(a,Double)]
+importance' :: (Ord a, Typeable a) => Int -> EmpiricalT Sampler a -> Sampler [(a,Double)]
 importance' n d = fmap (enumerate . categorical) $ toCat $ population n >> d
 
 -- | Sequential Monte Carlo from the prior.
@@ -37,5 +38,5 @@ smc n d = fmap (\(Left x) -> x) $ run start where
       if finished then particles else run (step particles)
 
 -- | `smc` with post-processing.
-smc' :: Ord a => Int -> ParticleT (EmpiricalT Sampler) a -> Sampler [(a,Double)]
+smc' :: (Ord a, Typeable a) => Int -> ParticleT (EmpiricalT Sampler) a -> Sampler [(a,Double)]
 smc' n d = fmap (enumerate . categorical) $ toCat $ smc n d

--- a/src/Primitive.hs
+++ b/src/Primitive.hs
@@ -6,11 +6,12 @@ module Primitive where
 
 import Numeric.SpecFunctions
 import Data.Number.LogFloat (LogFloat, logFloat, logToLogFloat)
+import Data.Typeable
 
 -- | Primitive distributions for which we can compute density.
 -- Here the weights of Categorical must be normalized.
 data Primitive a where
-    Categorical :: Eq a => [(a,LogFloat)] -> Primitive a
+    Categorical :: (Eq a, Typeable a) => [(a,LogFloat)] -> Primitive a
     Normal :: Double -> Double -> Primitive Double
     Gamma :: Double -> Double -> Primitive Double
     Beta :: Double -> Double -> Primitive Double


### PR DESCRIPTION
Reason: Samples in the same position in the trace may have different types across executions. To decide whether a previous sample can be reused, we need to check its type at runtime.
