### PR TITLE
Change reuse policy of trace MH

### DIFF
--- a/models/StrictlySmallerSupport.hs
+++ b/models/StrictlySmallerSupport.hs
@@ -1,0 +1,12 @@
+-- A model in which a random value switches between
+-- two distributions, one with a support strictly
+-- smaller than the other.
+module StrictlySmallerSupport where
+
+import Control.Monad.Bayes.Class
+
+model :: MonadDist m => m Bool
+model = do
+  x <- bernoulli 0.5
+  y <- uniformD (if x then [1, 2] else [1, 2, 3, 4] :: [Int])
+  return x

--- a/monad-bayes.cabal
+++ b/monad-bayes.cabal
@@ -86,7 +86,8 @@ benchmark monad-bayes-bench
   -- List all models we want to watch for changes.
   -- DO NOT list modules that don't compile.
   -- They make it impossible to run `stack ghci`.
-  other-modules:       Sprinkler, BetaBin, Dice, Gamma, HMM, DPmixture
+  other-modules:       Sprinkler, BetaBin, Dice, Gamma, HMM, DPmixture,
+                       StrictlySmallerSupport
 
 source-repository head
   type:     git

--- a/src/Control/Monad/Bayes/Trace.hs
+++ b/src/Control/Monad/Bayes/Trace.hs
@@ -23,8 +23,6 @@ import Data.Number.LogFloat hiding (sum)
 import System.Random (mkStdGen)
 import Text.Printf
 
-import Debug.Trace
-
 import Control.Monad.Bayes.Primitive
 import Control.Monad.Bayes.Class
 import Control.Monad.Bayes.Dist (normalize)

--- a/src/Control/Monad/Bayes/Trace.hs
+++ b/src/Control/Monad/Bayes/Trace.hs
@@ -91,22 +91,18 @@ reusablePrimitive d x d' =
     return ((x', pdf d' x'), eq x')
 
 data Support a where
-  Real           :: Support Double
-  PositiveReal   :: Support Double
   OpenInterval   :: Double -> Double -> Support Double
   ClosedInterval :: Double -> Double -> Support Double
   Discrete       :: (Eq a, Typeable a) => [a] -> Support a
 
 getSupport :: Primitive a -> Support a
 getSupport (Categorical xs) = Discrete (map fst xs)
-getSupport (Normal  _ _)    = Real
-getSupport (Gamma   _ _)    = PositiveReal
+getSupport (Normal  _ _)    = OpenInterval (-1/0) (1/0)
+getSupport (Gamma   _ _)    = OpenInterval 0 (1/0)
 getSupport (Beta    _ _)    = OpenInterval 0 1
 getSupport (Uniform a b)    = ClosedInterval a b
 
 compareSupport :: Support a -> Support b -> Maybe ((a -> b), (b -> b -> Bool))
-compareSupport  Real                 Real                 = Just (id, (==))
-compareSupport  PositiveReal         PositiveReal         = Just (id, (==))
 compareSupport  (OpenInterval   a b) (OpenInterval   c d) = if [a, b] == [c, d] then Just (id, (==)) else Nothing
 compareSupport  (ClosedInterval a b) (ClosedInterval c d) = if [a, b] == [c, d] then Just (id, (==)) else Nothing
 compareSupport  (Discrete       xs)  (Discrete       ys)  = if maybe False (== ys) (cast xs) then Just (fromJust . cast, (==)) else Nothing

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -75,6 +75,8 @@ main = hspec $ do
       TestInference.check_prior_trans `shouldBe` True
     it "Trace MH leaves posterior invariant" $ do
       TestInference.check_trace_trans `shouldBe` True
+    it "Trace MH leaves posterior invariant when the model has shifting support" $ do
+      TestInference.check_trace_support `shouldBe` True
     -- too large to execute
     -- it "PIMH leaves posterior invariant" $ do
     --   TestInference.check_pimh_trans `shouldBe` True


### PR DESCRIPTION
Previously, trace MH reuses previous values if they have positive density in the new distribution. This is incorrect.
- a82d450a084a0f31cc73f8c7c4c214e8e3b624c8 adds a model where trace MH fails. 
- 505d1916d546910c9ba43444206a2f523a239311 fixes the test failure by changing the reuse policy. Now trace MH reuses old samples only if the old and new distributions have identical support.
- 58fae397eabc69f68637278ea0fe9b91d31d33c7 deletes a spurious import.
