### PR TITLE
Add a Dirichlet distribution across all monads

### DIFF
--- a/src/Control/Monad/Bayes/Class.hs
+++ b/src/Control/Monad/Bayes/Class.hs
@@ -65,6 +65,13 @@ class Monad m => MonadDist m where
       i <- discrete (map snd d)
       return (fst (d !! i))
 
+    -- | Dirichlet distribution, the conjugate prior to the categorical.
+    -- Weights need not be normalized.
+    dirichlet :: [Double] -> m [Double]
+    dirichlet ws = liftM normalize $ gammas ws where
+      gammas = mapM (\w -> gamma w 1)
+      normalize xs = map (/ (Prelude.sum xs)) xs
+
     -- | Bernoulli distribution.
     bernoulli :: LogFloat -> m Bool
     bernoulli p = categorical [(True,p), (False,1-p)]


### PR DESCRIPTION
The Dirichlet distribution is added as a compound distribution, built by
sampling from a series of Gammas inside whichever probability monad has been
chosen.

Signed-off-by: Eli Sennesh eligottlieb@gmail.com
