### PR TITLE
Making some pattern-matchings irrefutable so we can build on recent GHC

### DIFF
--- a/src/Control/Monad/Bayes/Traced/Basic.hs
+++ b/src/Control/Monad/Bayes/Traced/Basic.hs
@@ -76,6 +76,6 @@ mh n (Traced m d) = fmap (map output) t where
   t = f n
   f 0 = fmap (:[]) d
   f k = do
-    x:xs <- f (k-1)
+    ~(x:xs) <- f (k-1)
     y <- mhTrans' m x
     return (y:x:xs)

--- a/src/Control/Monad/Bayes/Traced/Dynamic.hs
+++ b/src/Control/Monad/Bayes/Traced/Dynamic.hs
@@ -93,7 +93,7 @@ mh n (Traced c) = do
   (m,t) <- c
   let f 0 = return [t]
       f k = do
-        x:xs <- f (k-1)
+        ~(x:xs) <- f (k-1)
         y <- mhTrans m x
         return (y:x:xs)
   ts <- f n

--- a/src/Control/Monad/Bayes/Traced/Static.hs
+++ b/src/Control/Monad/Bayes/Traced/Static.hs
@@ -75,6 +75,6 @@ mh n (Traced m d) = fmap (map output) t where
   t = f n
   f 0 = fmap (:[]) d
   f k = do
-    x:xs <- f (k-1)
+    ~(x:xs) <- f (k-1)
     y <- mhTrans m x
     return (y:x:xs)


### PR DESCRIPTION
This fixes https://github.com/adscib/monad-bayes/pull/48 without the need for MonadFail constraints