### PR TITLE
fix build on ghc 8.6

### DIFF
--- a/src/Control/Monad/Bayes/Traced/Basic.hs
+++ b/src/Control/Monad/Bayes/Traced/Basic.hs
@@ -76,6 +76,6 @@ mh n (Traced m d) = fmap (map output) t where
   t = f n
   f 0 = fmap (:[]) d
   f k = do
-    x:xs <- f (k-1)
-    y <- mhTrans' m x
-    return (y:x:xs)
+    xxs <- f (k-1)
+    y <- mhTrans' m (head xxs)
+    return (y:xxs) 

--- a/src/Control/Monad/Bayes/Traced/Dynamic.hs
+++ b/src/Control/Monad/Bayes/Traced/Dynamic.hs
@@ -93,9 +93,9 @@ mh n (Traced c) = do
   (m,t) <- c
   let f 0 = return [t]
       f k = do
-        x:xs <- f (k-1)
-        y <- mhTrans m x
-        return (y:x:xs)
+        xxs <- f (k-1)
+        y <- mhTrans m (head xxs)
+        return (y:xxs) 
   ts <- f n
   let xs = map output ts
   return xs

--- a/src/Control/Monad/Bayes/Traced/Static.hs
+++ b/src/Control/Monad/Bayes/Traced/Static.hs
@@ -75,6 +75,6 @@ mh n (Traced m d) = fmap (map output) t where
   t = f n
   f 0 = fmap (:[]) d
   f k = do
-    x:xs <- f (k-1)
-    y <- mhTrans m x
-    return (y:x:xs)
+    xxs <- f (k-1)
+    y <- mhTrans m (head xxs)
+    return (y:xxs) 


### PR DESCRIPTION
It fixes error regarding missing MonadFail instances 

```
src/Control/Monad/Bayes/Traced/Static.hs:78:5: error:
    • Could not deduce (MonadFail m)
        arising from a do statement
        with the failable pattern ‘x : xs’
      from the context: MonadSample m
        bound by the type signature for:
                   mh :: forall (m :: * -> *) a.
                         MonadSample m =>
                         Int -> Traced m a -> m [a]
        at src/Control/Monad/Bayes/Traced/Static.hs:73:1-49
      Possible fix:
        add (MonadFail m) to the context of
          the type signature for:
            mh :: forall (m :: * -> *) a.
                  MonadSample m =>
                  Int -> Traced m a -> m [a]
    • In a stmt of a 'do' block: x : xs <- f (k - 1)
      In the expression:
        do x : xs <- f (k - 1)
           y <- mhTrans m x
           return (y : x : xs)
      In an equation for ‘f’:
          f k
            = do x : xs <- f (k - 1)
                 y <- mhTrans m x
                 return (y : x : xs)
   |
78 |     x:xs <- f (k-1)
   |     ^^^^^^^^^^^^^^^
```
