### PR TITLE
fixed errors that blocked stack build for later lts

### DIFF
--- a/src/Control/Monad/Bayes/Traced/Basic.hs
+++ b/src/Control/Monad/Bayes/Traced/Basic.hs
@@ -76,6 +76,6 @@ mh n (Traced m d) = fmap (map output) t where
   t = f n
   f 0 = fmap (:[]) d
   f k = do
-    x:xs <- f (k-1)
-    y <- mhTrans' m x
-    return (y:x:xs)
+    l <- f (k-1)
+    y <- mhTrans' m (head l)
+    return (y:l)

--- a/src/Control/Monad/Bayes/Traced/Dynamic.hs
+++ b/src/Control/Monad/Bayes/Traced/Dynamic.hs
@@ -93,9 +93,9 @@ mh n (Traced c) = do
   (m,t) <- c
   let f 0 = return [t]
       f k = do
-        x:xs <- f (k-1)
-        y <- mhTrans m x
-        return (y:x:xs)
+        l <- f (k-1)
+        y <- mhTrans m (head l)
+        return (y:l)
   ts <- f n
   let xs = map output ts
   return xs

--- a/src/Control/Monad/Bayes/Traced/Static.hs
+++ b/src/Control/Monad/Bayes/Traced/Static.hs
@@ -75,6 +75,6 @@ mh n (Traced m d) = fmap (map output) t where
   t = f n
   f 0 = fmap (:[]) d
   f k = do
-    x:xs <- f (k-1)
-    y <- mhTrans m x
-    return (y:x:xs)
+    l <- f (k-1)
+    y <- mhTrans m (head l)
+    return (y:l)


### PR DESCRIPTION
#### The Problem
In the latest stack lts, `x:xs <- f ...` is a compile time error if the underlying monad does not implement monad fail. Issue seemed to be that later versions of ghc require your monad to a MonadFail if you pattern match a bind on a sum type

#### The Fix
You can avoid the compiler's complaints by avoiding pattern matching. 
