### PR TITLE
expose the Trace.Common module

### DIFF
--- a/monad-bayes.cabal
+++ b/monad-bayes.cabal
@@ -48,7 +48,7 @@ library
                      , Control.Monad.Bayes.Inference.RMSMC
                      , Control.Monad.Bayes.Inference.PMMH
                      , Control.Monad.Bayes.Inference.SMC2
-  other-modules:       Control.Monad.Bayes.Traced.Common
+                     , Control.Monad.Bayes.Traced.Common
   build-depends:       base >= 4.7 && < 5
                      , containers
                      , mtl


### PR DESCRIPTION
This PR exposes the `Traced.Commons` module with some useful functions and the `Trace` type:

https://github.com/adscib/monad-bayes/blob/master/src/Control/Monad/Bayes/Traced/Common.hs#L12-L20

Is there a reason that it is currently hidden?