### PR TITLE
(docs) add Hackage and reverse dependency badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # monad-bayes
 
-[![Build Status](https://travis-ci.org/tweag/monad-bayes.svg?branch=master)](https://travis-ci.org/tweag/monad-bayes)
+[![Hackage](https://img.shields.io/hackage/v/monad-bayes.svg)](https://hackage.haskell.org/package/monad-bayes) [![Hackage Deps](https://img.shields.io/hackage-deps/v/monad-bayes.svg)](http://packdeps.haskellers.com/reverse/monad-bayes)
 
 A library for **probabilistic programming in Haskell** using probability
 monads. The emphasis is on composition of inference algorithms implemented in


### PR DESCRIPTION
Also remove Travis CI badge - it's no longer used; migration to BuildKite is in progress: https://github.com/tweag/monad-bayes/pull/63

**[Preview here.](https://github.com/tweag/monad-bayes/blob/shields/README.md#monad-bayes)**