### PR TITLE
(refactor) get rid of unused import

### DIFF
--- a/src/Control/Monad/Bayes/Enumerator.hs
+++ b/src/Control/Monad/Bayes/Enumerator.hs
@@ -22,7 +22,7 @@ module Control.Monad.Bayes.Enumerator (
             ) where
 
 import Data.AEq (AEq, (===), (~==))
-import Control.Applicative (Applicative, Alternative)
+import Control.Applicative (Alternative)
 import Control.Monad (MonadPlus)
 import Control.Arrow (second)
 import qualified Data.Map as Map


### PR DESCRIPTION
Gets rid of this warning:

<pre>/monad-bayes-0.1.0.0/<b>src/Control/Monad/Bayes/Enumerator.hs:25:1: </b><font color="#75507B"><b>warning:</b></font><b> [</b><font color="#75507B"><b>-Wunused-imports</b></font><b>]</b>
    The import of `Applicative&apos;
    from module `Control.Applicative&apos; is redundant
<font color="#3465A4"><b>   |</b></font>                       
<font color="#3465A4"><b>25 |</b></font> <font color="#75507B"><b>import Control.Applicative (Applicative, Alternative)</b></font>
<font color="#3465A4"><b>   |</b></font><font color="#75507B"><b> ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^</b></font>
</pre>