### PR TITLE
(ci) check cabal file formatting

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,13 +1,18 @@
 steps:
-  - label: GHC 8.4
+  - label: Lint and check formatting
+    command: |
+      nix-build -A lint -o lint.sh
+      ./lint.sh
+    timeout: 10
+  - label: Build and test on GHC 8.4
     command: |
       nix-build -A monad-bayes-ghc84 --no-out-link
     timeout: 100
-  - label: GHC 8.6
+  - label: Build and test on GHC 8.6
     command: |
       nix-build -A monad-bayes-ghc86 --no-out-link
     timeout: 100
-  - label: GHC 8.8
+  - label: Build and test on GHC 8.8
     command: |
       nix-build -A monad-bayes-ghc88 --no-out-link
     timeout: 100

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 *.eventlog
 *.hi
 *.hp
+*.lock
 *.o
 *.prof
 .HTF/
@@ -20,4 +21,3 @@ cabal.project.local~
 cabal.sandbox.config
 dist
 dist-*
-stack.yaml.lock

--- a/default.nix
+++ b/default.nix
@@ -18,13 +18,15 @@ let
   monad-bayes-ghc84 = mkMonadBayes "stack-ghc844.yaml";
   monad-bayes-ghc86 = mkMonadBayes "stack-ghc865.yaml";
   monad-bayes-ghc88 = mkMonadBayes "stack-ghc881.yaml";
+
+  defaultHaskellPackages = pkgs.haskell.packages.ghc865;
 in {
   inherit monad-bayes-ghc84 monad-bayes-ghc86 monad-bayes-ghc88;
   shell = monad-bayes-ghc86.shellFor {
     packages = ps: [
       ps.monad-bayes
     ];
-    buildInputs = with pkgs.haskell.packages.ghc865; [
+    buildInputs = with defaultHaskellPackages; [
       cabal-install
       ghcid
       hindent
@@ -36,4 +38,5 @@ in {
       pkgs.stack
     ];
   };
+  lint = defaultHaskellPackages.callPackage ./nix/lint.nix {};
 }

--- a/default.nix
+++ b/default.nix
@@ -29,7 +29,6 @@ in {
       ghcid
       hindent
       hlint
-      stylish-cabal
       pkgs.nixpkgs-fmt
       pkgs.python37
       pkgs.python37Packages.matplotlib

--- a/monad-bayes.cabal
+++ b/monad-bayes.cabal
@@ -1,171 +1,183 @@
-cabal-version:       2.0
-tested-with:         GHC==8.4.4, GHC==8.6.5, GHC==8.8.1
-name:                monad-bayes
-version:             0.1.0.0
-synopsis:            A library for probabilistic programming.
-description:         A library for probabilistic programming using probability monads. The emphasis is on composition of inference algorithms implemented in terms of monad transformers.
-homepage:            http://github.com/tweag/monad-bayes#readme
-license:             MIT
-license-file:        LICENSE.md
-author:              Adam Scibior <adscib@gmail.com>
-maintainer:          leonhard.markert@tweag.io
-copyright:           2015-2020 Adam Scibior
-bug-reports:         https://github.com/tweag/monad-bayes/issues
-stability:           experimental
-category:            Statistics
-build-type:          Simple
-extra-source-files:
-  CHANGELOG.md
+cabal-version:      2.0
+name:               monad-bayes
+version:            0.1.0.0
+license:            MIT
+license-file:       LICENSE.md
+copyright:          2015-2020 Adam Scibior
+maintainer:         leonhard.markert@tweag.io
+author:             Adam Scibior <adscib@gmail.com>
+stability:          experimental
+tested-with:        ghc ==8.4.4 ghc ==8.6.5 ghc ==8.8.1
+homepage:           http://github.com/tweag/monad-bayes#readme
+bug-reports:        https://github.com/tweag/monad-bayes/issues
+synopsis:           A library for probabilistic programming.
+description:
+    A library for probabilistic programming using probability monads. The
+    emphasis is on composition of inference algorithms implemented in
+    terms of monad transformers.
 
-flag dev
-  description: Turn on development settings.
-  manual: True
-  default: False
-
-executable example
-  hs-source-dirs:      benchmark, models
-  main-is:             Single.hs
-  build-depends:       base
-                     , monad-bayes
-                     , log-domain
-                     , vector
-                     , containers
-                     , mwc-random
-                     , time
-                     , optparse-applicative
-  default-language:    Haskell2010
-  other-modules:       LogReg
-                     , HMM
-                     , LDA
-                     , Dice
-  if flag(dev)
-    ghc-options: -Wall -Wcompat
-                 -Wincomplete-record-updates
-                 -Wincomplete-uni-patterns
-                 -Wnoncanonical-monad-instances
-  else
-    ghc-options: -Wall
-
-library
-  hs-source-dirs:      src
-  exposed-modules:     Control.Monad.Bayes.Class
-                     , Control.Monad.Bayes.Free
-                     , Control.Monad.Bayes.Sampler
-                     , Control.Monad.Bayes.Weighted
-                     , Control.Monad.Bayes.Sequential
-                     , Control.Monad.Bayes.Population
-                     , Control.Monad.Bayes.Traced.Static
-                     , Control.Monad.Bayes.Traced.Dynamic
-                     , Control.Monad.Bayes.Traced.Basic
-                     , Control.Monad.Bayes.Traced
-                     , Control.Monad.Bayes.Enumerator
-                     , Control.Monad.Bayes.Helpers
-                     , Control.Monad.Bayes.Inference.SMC
-                     , Control.Monad.Bayes.Inference.RMSMC
-                     , Control.Monad.Bayes.Inference.PMMH
-                     , Control.Monad.Bayes.Inference.SMC2
-  other-modules:       Control.Monad.Bayes.Traced.Common
-  -- See MAINTAINERS.md for when and how to update the version bounds.
-  build-depends:       base >= 4.11 && < 4.14
-                     , containers >= 0.5.10 && < 0.7
-                     , free >= 5.0.2 && < 5.2
-                     , ieee754 >= 0.8.0 && < 0.9
-                     , log-domain >= 0.12 && < 0.14
-                     , math-functions >= 0.2.1 && < 0.4
-                     , monad-coroutine >= 0.9.0 && < 0.10
-                     , mtl >= 2.2.2 && < 2.3
-                     , mwc-random >= 0.13.6 && < 0.15
-                     , safe >= 0.3.17 && < 0.4
-                     , statistics >= 0.14.0 && < 0.16
-                     , transformers >= 0.5.2 && < 0.6
-                     , vector >= 0.12.0 && < 0.13
-  if flag(dev)
-    ghc-options: -Wall -Wcompat
-                 -Wincomplete-record-updates
-                 -Wincomplete-uni-patterns
-                 -Wnoncanonical-monad-instances
-  else
-    ghc-options: -Wall
-  default-language:    Haskell2010
-  default-extensions:  RankNTypes
-                     , GeneralizedNewtypeDeriving
-                     , StandaloneDeriving
-                     , TypeFamilies
-                     , FlexibleContexts
-                     , FlexibleInstances
-                     , TupleSections
-                     , MultiParamTypeClasses
-                     , GADTs
-  other-extensions:    ScopedTypeVariables
-                     , DeriveFunctor
-
-test-suite monad-bayes-test
-  type:                exitcode-stdio-1.0
-  hs-source-dirs:      test, models
-  main-is:             Spec.hs
-  build-depends:       base
-                     , monad-bayes
-                     , hspec
-                     , QuickCheck
-                     , ieee754
-                     , mtl
-                     , math-functions
-                     , transformers
-                     , log-domain
-                     , vector
-  if flag(dev)
-    ghc-options: -Wall -Wcompat
-                 -Wincomplete-record-updates
-                 -Wincomplete-uni-patterns
-                 -Wnoncanonical-monad-instances
-  else
-    ghc-options: -Wall
-  default-language:    Haskell2010
-  other-modules:       Sprinkler,
-                       TestEnumerator,
-                       TestPopulation,
-                       TestInference,
-                       TestSequential,
-                       TestWeighted
-
-benchmark ssm-bench
-  type:                exitcode-stdio-1.0
-  hs-source-dirs:      models
-                     , benchmark
-  build-depends:       base
-                     , monad-bayes
-  default-language:    Haskell2010
-  default-extensions:  RankNTypes
-  main-is:             SSM.hs
-  other-modules:       NonlinearSSM
-
-benchmark speed-bench
-  type:                exitcode-stdio-1.0
-  hs-source-dirs:      models
-                     , benchmark
-  build-depends:       base
-                     , monad-bayes
-                     , criterion
-                     , abstract-par
-                     , log-domain
-                     , vector
-                     , mwc-random
-                     , containers
-                     , process
-  if flag(dev)
-    ghc-options: -Wall -Wcompat
-                 -Wincomplete-record-updates
-                 -Wincomplete-uni-patterns
-                 -Wnoncanonical-monad-instances
-  else
-    ghc-options: -Wall
-  default-language:    Haskell2010
-  default-extensions:  RankNTypes
-  main-is:             Speed.hs
-  other-modules:       LogReg
-                     , HMM
-                     , LDA
+category:           Statistics
+build-type:         Simple
+extra-source-files: CHANGELOG.md
 
 source-repository head
-  type:     git
-  location: https://github.com/tweag/monad-bayes.git
+    type:     git
+    location: https://github.com/tweag/monad-bayes.git
+
+flag dev
+    description: Turn on development settings.
+    default:     False
+    manual:      True
+
+library
+    exposed-modules:
+        Control.Monad.Bayes.Class
+        Control.Monad.Bayes.Enumerator
+        Control.Monad.Bayes.Free
+        Control.Monad.Bayes.Helpers
+        Control.Monad.Bayes.Inference.PMMH
+        Control.Monad.Bayes.Inference.RMSMC
+        Control.Monad.Bayes.Inference.SMC
+        Control.Monad.Bayes.Inference.SMC2
+        Control.Monad.Bayes.Population
+        Control.Monad.Bayes.Sampler
+        Control.Monad.Bayes.Sequential
+        Control.Monad.Bayes.Traced
+        Control.Monad.Bayes.Traced.Basic
+        Control.Monad.Bayes.Traced.Dynamic
+        Control.Monad.Bayes.Traced.Static
+        Control.Monad.Bayes.Weighted
+
+    hs-source-dirs:     src
+    other-modules:      Control.Monad.Bayes.Traced.Common
+    default-language:   Haskell2010
+    default-extensions:
+        MultiParamTypeClasses RankNTypes FlexibleContexts FlexibleInstances
+        GeneralizedNewtypeDeriving TypeFamilies StandaloneDeriving GADTs
+        TupleSections
+
+    other-extensions:   ScopedTypeVariables DeriveFunctor
+    build-depends:
+        base >=4.11 && <4.14,
+        containers >=0.5.10 && <0.7,
+        free >=5.0.2 && <5.2,
+        ieee754 >=0.8.0 && <0.9,
+        log-domain >=0.12 && <0.14,
+        math-functions >=0.2.1 && <0.4,
+        monad-coroutine >=0.9.0 && <0.10,
+        mtl >=2.2.2 && <2.3,
+        mwc-random >=0.13.6 && <0.15,
+        safe >=0.3.17 && <0.4,
+        statistics >=0.14.0 && <0.16,
+        transformers >=0.5.2 && <0.6,
+        vector >=0.12.0 && <0.13
+
+    if flag(dev)
+        ghc-options:
+            -Wall -Wcompat -Wincomplete-record-updates
+            -Wincomplete-uni-patterns -Wnoncanonical-monad-instances
+
+    else
+        ghc-options: -Wall
+
+executable example
+    main-is:          Single.hs
+    hs-source-dirs:   benchmark models
+    other-modules:
+        Dice
+        HMM
+        LDA
+        LogReg
+
+    default-language: Haskell2010
+    build-depends:
+        base -any,
+        containers -any,
+        log-domain -any,
+        monad-bayes -any,
+        mwc-random -any,
+        optparse-applicative -any,
+        time -any,
+        vector -any
+
+    if flag(dev)
+        ghc-options:
+            -Wall -Wcompat -Wincomplete-record-updates
+            -Wincomplete-uni-patterns -Wnoncanonical-monad-instances
+
+    else
+        ghc-options: -Wall
+
+test-suite monad-bayes-test
+    type:             exitcode-stdio-1.0
+    main-is:          Spec.hs
+    hs-source-dirs:   test models
+    other-modules:
+        Sprinkler
+        TestEnumerator
+        TestInference
+        TestPopulation
+        TestSequential
+        TestWeighted
+
+    default-language: Haskell2010
+    build-depends:
+        base -any,
+        QuickCheck -any,
+        hspec -any,
+        ieee754 -any,
+        log-domain -any,
+        math-functions -any,
+        monad-bayes -any,
+        mtl -any,
+        transformers -any,
+        vector -any
+
+    if flag(dev)
+        ghc-options:
+            -Wall -Wcompat -Wincomplete-record-updates
+            -Wincomplete-uni-patterns -Wnoncanonical-monad-instances
+
+    else
+        ghc-options: -Wall
+
+benchmark ssm-bench
+    type:               exitcode-stdio-1.0
+    main-is:            SSM.hs
+    hs-source-dirs:     models benchmark
+    other-modules:      NonlinearSSM
+    default-language:   Haskell2010
+    default-extensions: RankNTypes
+    build-depends:
+        base -any,
+        monad-bayes -any
+
+benchmark speed-bench
+    type:               exitcode-stdio-1.0
+    main-is:            Speed.hs
+    hs-source-dirs:     models benchmark
+    other-modules:
+        HMM
+        LDA
+        LogReg
+
+    default-language:   Haskell2010
+    default-extensions: RankNTypes
+    build-depends:
+        base -any,
+        abstract-par -any,
+        containers -any,
+        criterion -any,
+        log-domain -any,
+        monad-bayes -any,
+        mwc-random -any,
+        process -any,
+        vector -any
+
+    if flag(dev)
+        ghc-options:
+            -Wall -Wcompat -Wincomplete-record-updates
+            -Wincomplete-uni-patterns -Wnoncanonical-monad-instances
+
+    else
+        ghc-options: -Wall

--- a/nix/lint.nix
+++ b/nix/lint.nix
@@ -1,0 +1,24 @@
+{ cabal-install
+, pkgs
+, writeScript
+}:
+
+writeScript "lint.sh" ''
+  set -euo pipefail
+  IFS=$'\n\t'
+
+  git="${pkgs.git}/bin/git"
+  cabal="${cabal-install}/bin/cabal"
+
+  if ! $git diff --quiet -- *.cabal; then
+      echo 'ERROR: Dirty working directory'
+      exit 1
+  fi
+  $cabal format *.cabal
+  if ! $git diff --quiet -- *.cabal; then
+      echo 'FAILURE: Cabal files were not formatted correctly'
+      exit 1
+  fi
+
+  echo 'SUCCESS: Cabal files are formatted correctly'
+''


### PR DESCRIPTION
This ensures that the Cabal file is formatted consistently. Other linters can now be added easily: see #71.

Introduces the command `eval $(nix-build . -A lint)` to run linters.