### PR TITLE
(ci) run HLint

### DIFF
--- a/benchmark/Single.hs
+++ b/benchmark/Single.hs
@@ -46,16 +46,16 @@ runAlg model alg =
     SMC ->
       let n = 100
           (k, m) = getModel model
-      in show <$> (runPopulation $ smcSystematic k n m)
+      in show <$> runPopulation (smcSystematic k n m)
     MH  ->
       let t = 100
           (_, m) = getModel model
-      in show <$> (prior $ mh t m)
+      in show <$> prior (mh t m)
     RMSMC ->
       let n = 10
           t = 1
           (k, m) = getModel model
-      in show <$> (runPopulation $ rmsmcBasic k n t m)
+      in show <$> runPopulation (rmsmcBasic k n t m)
 
 
 infer :: Model -> Alg -> IO ()

--- a/default.nix
+++ b/default.nix
@@ -27,6 +27,7 @@ in {
       ps.monad-bayes
     ];
     buildInputs = with defaultHaskellPackages; [
+      apply-refact
       cabal-install
       ghcid
       hindent
@@ -39,4 +40,5 @@ in {
     ];
   };
   lint = defaultHaskellPackages.callPackage ./nix/lint.nix {};
+  fix = defaultHaskellPackages.callPackage ./nix/fix.nix {};
 }

--- a/models/BenchAll.hs
+++ b/models/BenchAll.hs
@@ -25,6 +25,7 @@ import Control.Monad.Bayes.Population
 
 import System.IO
 import Control.Arrow (first, second)
+import Control.Applicative ((<$>))
 import Control.Monad (unless, when)
 import Control.Monad.IO.Class (MonadIO, liftIO)
 
@@ -86,7 +87,7 @@ hmmBenchmark = do
   let isRes = map (\n -> HMM.hmmKL $ take n isSamples) ns
   -- mhSamples <- fmap (drop 5000) $ traceMH 10000 HMM.hmm
   -- let mhRes = map (\n -> HMM.hmmKL $ take n $ map (,1) mhSamples) ns
-  mhPriorSamples <- fmap (drop 5000) $ mhPrior HMM.hmm 10000
+  mhPriorSamples <- drop 5000 <$> mhPrior HMM.hmm 10000
   let mhPriorRes = map (\n -> HMM.hmmKL $ take n $ map (,1) mhPriorSamples) ns
   pimhSamples <- pimh (length HMM.values) 100 1000 HMM.hmm
   let pimhRes = map (\n -> HMM.hmmKL $ take n $ map (,1) pimhSamples) ns

--- a/models/Branching.hs
+++ b/models/Branching.hs
@@ -12,7 +12,7 @@ branching :: (MonadBayes m, CustomReal m ~ Double) => m Int
 branching = do
   let count_prior = discrete $ replicate 10 0.1 -- TODO: change to poisson 4
   r <- count_prior
-  l <- if (4 < r) then
+  l <- if 4 < r then
          return 6
        else
          fmap (+ fib (3*r)) count_prior

--- a/models/Dice.hs
+++ b/models/Dice.hs
@@ -18,15 +18,15 @@ dice 1 = die
 dice n = liftM2 (+) die (dice (n-1))
 
 -- | Toss of two dice where the output is greater than 4.
-dice_hard :: MonadInfer m => m Int
-dice_hard = do
+diceHard :: MonadInfer m => m Int
+diceHard = do
   result <- dice 2
   condition (result > 4)
   return result
 
 -- | Toss of two dice with an artificial soft constraint.
-dice_soft :: MonadInfer m => m Int
-dice_soft = do
+diceSoft :: MonadInfer m => m Int
+diceSoft = do
   result <- dice 2
   score (1 / fromIntegral result)
   return result

--- a/models/HMM.hs
+++ b/models/HMM.hs
@@ -31,10 +31,9 @@ trans 2 = categorical $ fromList [0.15,0.7,0.15]
 
 -- | The emission model.
 emissionMean :: Int -> Double
-emissionMean x = mean x where
-  mean 0 = -1
-  mean 1 = 1
-  mean 2 = 0
+emissionMean 0 = -1
+emissionMean 1 = 1
+emissionMean 2 = 0
 
 -- | Initial state distribution
 start :: MonadSample m => m Int

--- a/models/LDA.hs
+++ b/models/LDA.hs
@@ -24,26 +24,26 @@ docs = [
   words "bear wolf bear python bear wolf bear wolf bear wolf"
   ]
 
-word_dist_prior :: MonadSample m => m (Vector Double)
-word_dist_prior = dirichlet $ V.replicate (length vocabluary) 1
+wordDistPrior :: MonadSample m => m (Vector Double)
+wordDistPrior = dirichlet $ V.replicate (length vocabluary) 1
 
-topic_dist_prior :: MonadSample m => m (Vector Double)
-topic_dist_prior = dirichlet $ V.replicate (length topics) 1
+topicDistPrior :: MonadSample m => m (Vector Double)
+topicDistPrior = dirichlet $ V.replicate (length topics) 1
 
-word_index :: Map.Map String Int
-word_index = Map.fromList $ zip vocabluary [0..]
+wordIndex :: Map.Map String Int
+wordIndex = Map.fromList $ zip vocabluary [0..]
 
 lda :: MonadInfer m => [[String]] -> m [Int]
 lda docs = do
   word_dist_for_topic <- do
-    ts <- mapM (const word_dist_prior) [0 .. length topics]
+    ts <- mapM (const wordDistPrior) [0 .. length topics]
     return $ Map.fromList $ zip [0 .. length topics] ts
 
   let obs doc = do
-        topic_dist <- fmap categorical topic_dist_prior
+        topic_dist <- fmap categorical topicDistPrior
         let f word = do
               topic <- topic_dist
-              factor $ (Exp . log) $ (word_dist_for_topic Map.! topic) V.! (word_index Map.! word)
+              factor $ (Exp . log) $ (word_dist_for_topic Map.! topic) V.! (wordIndex Map.! word)
         mapM_ f doc
 
   mapM_ obs docs

--- a/models/NonlinearSSM.hs
+++ b/models/NonlinearSSM.hs
@@ -12,6 +12,9 @@ param = do
   let sigmaY = 1 / sqrt precY
   return (sigmaX, sigmaY)
 
+mean :: Double -> Int -> Double
+mean x n = 0.5 * x + 25 * x / (1 + sq x) + 8 * cos (1.2 * fromIntegral n)
+
 -- | A nonlinear series model from Doucet et al. (2000)
 -- "On sequential Monte Carlo sampling methods" section VI.B
 model :: (MonadInfer m)
@@ -23,9 +26,7 @@ model obs (sigmaX, sigmaY) = do
       simulate [] _ acc = return acc
       simulate (y:ys) x acc = do
         let n = length acc
-        let mean = 0.5 * x + 25 * x / (1 + sq x) +
-                   8 * cos (1.2 * fromIntegral n)
-        x' <- normal mean sigmaX
+        x' <- normal (mean x n) sigmaX
         factor $ normalPdf (sq x' / 20) sigmaY y
         simulate ys x' (x':acc)
 
@@ -42,9 +43,7 @@ generateData t = do
       simulate 0 _ acc = return acc
       simulate k x acc = do
         let n = length acc
-        let mean = 0.5 * x + 25 * x / (1 + sq x) +
-                   8 * cos (1.2 * fromIntegral n)
-        x' <- normal mean sigmaX
+        x' <- normal (mean x n) sigmaX
         y' <- normal (sq x' / 20) sigmaY
         simulate (k-1) x' ((x',y'):acc)
 

--- a/models/Plotting.hs
+++ b/models/Plotting.hs
@@ -11,6 +11,8 @@ import Statistics.Sample (meanVariance)
 
 import Graphics.Rendering.Chart.Easy
 
+{-# ANN module "HLint: ignore Reduce duplication" #-}
+
 errBars :: Double -> Vector.Vector Double -> (Double, Double)
 errBars k xs = (mean, k * stdDev) where
   (mean, var) = meanVariance xs
@@ -27,10 +29,10 @@ anytimePlot x_title y_title ns inputs = do
 
   let generatePlot (algName, ys) = plot $ line algName [zip (map fromIntegral ns) (map LogValue ys)]
 
-  sequence_ $ map generatePlot inputs
+  mapM_ generatePlot inputs
 
-  layout_x_axis . laxis_generate .= (autoScaledLogAxis $ loga_labelf .~ xLabelShow $ def)
-  layout_y_axis . laxis_generate .= (autoScaledLogAxis $ loga_labelf .~ yLabelShow $ def)
+  layout_x_axis . laxis_generate .= autoScaledLogAxis (loga_labelf .~ xLabelShow $ def)
+  layout_y_axis . laxis_generate .= autoScaledLogAxis (loga_labelf .~ yLabelShow $ def)
 
   layout_x_axis . laxis_title .= x_title
   layout_y_axis . laxis_title .= y_title
@@ -45,10 +47,10 @@ oneShotPlot x_title y_title inputs = do
       plot $ points algName $ map (\(x, (y,_)) -> (LogValue x, LogValue y)) ps;
       plot $ return (def & plot_errbars_values .~ map processPoint ps)}
 
-  sequence_ $ map generatePlot inputs
+  mapM_ generatePlot inputs
 
-  layout_x_axis . laxis_generate .= (autoScaledLogAxis $ loga_labelf .~ xLabelShow $ def)
-  layout_y_axis . laxis_generate .= (autoScaledLogAxis $ loga_labelf .~ yLabelShow $ def)
+  layout_x_axis . laxis_generate .= autoScaledLogAxis (loga_labelf .~ xLabelShow $ def)
+  layout_y_axis . laxis_generate .= autoScaledLogAxis (loga_labelf .~ yLabelShow $ def)
 
   layout_x_axis . laxis_title .= x_title
   layout_y_axis . laxis_title .= y_title
@@ -76,10 +78,10 @@ errorbarPlot x_title y_title inputs = do
         plot $ points algName
              $ map (\(x, ys) -> (LogValue x, LogValue (sum ys / fromIntegral (length ys)))) ps
 
-  sequence_ $ map generatePlot inputs
+  mapM_ generatePlot inputs
 
-  layout_x_axis . laxis_generate .= (autoScaledLogAxis $ loga_labelf .~ xLabelShow $ def)
-  layout_y_axis . laxis_generate .= (autoScaledLogAxis $ loga_labelf .~ yLabelShow $ def)
+  layout_x_axis . laxis_generate .= autoScaledLogAxis (loga_labelf .~ xLabelShow $ def)
+  layout_y_axis . laxis_generate .= autoScaledLogAxis (loga_labelf .~ yLabelShow $ def)
 
   layout_x_axis . laxis_title .= x_title
   layout_y_axis . laxis_title .= y_title

--- a/nix/fix.nix
+++ b/nix/fix.nix
@@ -1,0 +1,29 @@
+{ apply-refact
+, cabal-install
+, hlint
+, pkgs
+, writeScript
+}:
+
+writeScript "fix.sh" ''
+  set -euo pipefail
+  IFS=$'\n\t'
+
+  cabal="${cabal-install}/bin/cabal"
+  git="${pkgs.git}/bin/git"
+  hlint="${hlint}/bin/hlint"
+  refactor="${apply-refact}/bin/refactor"
+
+  if ! $git diff --quiet -- *.cabal; then
+      echo 'ERROR: Dirty working directory'
+      exit 1
+  fi
+
+  $cabal format *.cabal
+  echo 'SUCCESS: Formatted cabal file'
+
+  $git ls-tree -z -r HEAD --name-only | \
+      grep -z '\.hs$' | \
+      xargs -0 -I{} $hlint {} --refactor --with-refactor=$refactor --refactor-options="--inplace"
+  echo 'SUCCESS: Applied HLint suggestions'
+''

--- a/nix/lint.nix
+++ b/nix/lint.nix
@@ -1,4 +1,5 @@
 { cabal-install
+, hlint
 , pkgs
 , writeScript
 }:
@@ -7,18 +8,27 @@ writeScript "lint.sh" ''
   set -euo pipefail
   IFS=$'\n\t'
 
-  git="${pkgs.git}/bin/git"
   cabal="${cabal-install}/bin/cabal"
+  git="${pkgs.git}/bin/git"
+  hlint="${hlint}/bin/hlint"
 
   if ! $git diff --quiet -- *.cabal; then
       echo 'ERROR: Dirty working directory'
       exit 1
   fi
+
   $cabal format *.cabal
-  if ! $git diff --quiet -- *.cabal; then
+  if ! $git diff --exit-code -- *.cabal; then
       echo 'FAILURE: Cabal files were not formatted correctly'
+      echo 'Run "eval $(nix-build -A fix)" to fix this'
       exit 1
   fi
-
   echo 'SUCCESS: Cabal files are formatted correctly'
+
+  if ! $git ls-tree -z -r HEAD --name-only | grep -z '\.hs$' | xargs -0 $hlint; then
+      echo 'FAILURE: HLint reported issues'
+      echo 'Run "eval $(nix-build -A fix)" to attempt to fix this, manual fixes may be necessary'
+      exit 1
+  fi
+  echo 'SUCCESS: HLint reported no issues'
 ''

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -60,9 +60,9 @@ main = hspec $ do
         observations >= 0 && particles >= 1 ==> ioProperty $ do
           checkParticles <- TestInference.checkParticles observations particles
           return $ checkParticles == particles
-  describe "SMC with systematic resampling" $ do
+  describe "SMC with systematic resampling" $
     prop "number of particles is equal to its second parameter" $
-      \observations particles ->
-        observations >= 0 && particles >= 1 ==> ioProperty $ do
-          checkParticles <- TestInference.checkParticlesSystematic observations particles
-          return $ checkParticles == particles
+    \observations particles ->
+      observations >= 0 && particles >= 1 ==> ioProperty $ do
+        checkParticles <- TestInference.checkParticlesSystematic observations particles
+        return $ checkParticles == particles


### PR DESCRIPTION
Also adds `fix.nix`, which automatically fixes those formatting and linting errors that can be fixed automatically.

All changes to Haskell files in this PR came from `eval $(nix-build -A fix)`, which applies HLint's fixes.