### PR TITLE
(fix) benchmark compilation

### DIFF
--- a/benchmark/Speed.hs
+++ b/benchmark/Speed.hs
@@ -177,7 +177,7 @@ prepareBenchmark _ WebPPL model alg = bench name $ whnfIO run
     algString (RMSMC n t) = "--alg SMC --samples " ++ show n ++ " --rejuv " ++ show t ++ " "
     dataString (LR dataset) = let (xs, labels) = unzip dataset in "--xs='" ++ javascriptList xs ++ "' --labels='" ++ javascriptList (map (\b -> if b then 1 else 0) labels) ++ "'"
     dataString (HMM obs) = "--obs='" ++ javascriptList obs ++ "'"
-    dataString (LDA docs) = unwords $ zipWith (\x y -> "--doc" ++ show i ++ "='" ++ unwords doc ++ "'") [1 .. 5] docs
+    dataString (LDA docs) = unwords $ zipWith (\i doc -> "--doc" ++ show i ++ "='" ++ unwords doc ++ "'") [1 .. 5] docs
     run = do
       let command = "node " ++ webpplModelName model ++ ".js " ++ algString alg ++ dataString model
       (_, _, _, process) <- createProcess $ (shell command) {cwd = Just webpplPath, std_out = NoStream, std_err = NoStream}

--- a/models/NonlinearSSM.hs
+++ b/models/NonlinearSSM.hs
@@ -13,7 +13,7 @@ param = do
   return (sigmaX, sigmaY)
 
 mean :: Double -> Int -> Double
-mean x n = 0.5 * x + 25 * x / (1 + sq x) + 8 * cos (1.2 * fromIntegral n)
+mean x n = 0.5 * x + 25 * x / (1 + x * x) + 8 * cos (1.2 * fromIntegral n)
 
 -- | A nonlinear series model from Doucet et al. (2000)
 -- "On sequential Monte Carlo sampling methods" section VI.B


### PR DESCRIPTION
Broken by refactorings.

https://github.com/tweag/monad-bayes/issues/77 tracks the fact that this wasn't caught in CI.