### PR TITLE
(build) use lts-15.6 for GHC 8.8

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -35,7 +35,7 @@ let
       );
   monad-bayes-ghc84 = mkMonadBayes "stack-ghc844.yaml" false;
   monad-bayes-ghc86 = mkMonadBayes "stack-ghc865.yaml" true;
-  monad-bayes-ghc88 = mkMonadBayes "stack-ghc881.yaml" true;
+  monad-bayes-ghc88 = mkMonadBayes "stack-ghc883.yaml" true;
 
   defaultHaskellPackages = pkgs.haskell.packages.ghc865;
 in

--- a/nix/haskell-nix.json
+++ b/nix/haskell-nix.json
@@ -1,7 +1,7 @@
 {
   "url": "https://github.com/input-output-hk/haskell.nix.git",
-  "rev": "a93486531cdd1044520feec79c9a29af2cb92d8f",
-  "date": "2020-03-03T04:49:45+00:00",
-  "sha256": "0mbfs1cxv83gpfafpnfkf4rihsznnq5mbhfh1r9g9z60qv9llg7z",
+  "rev": "71f31cef4afd36c74d80d7527c7fd6549d1ad9f5",
+  "date": "2020-05-11T23:58:42+12:00",
+  "sha256": "00pwrbqlhy349jdnnjqn2d1577kvy00y70q5b34nk1wspbqyb2mp",
   "fetchSubmodules": false
 }

--- a/nix/nixpkgs.json
+++ b/nix/nixpkgs.json
@@ -1,7 +1,0 @@
-{
-  "url": "https://github.com/nixos/nixpkgs-channels.git",
-  "rev": "61cc1f0dc07c2f786e0acfd07444548486f4153b",
-  "date": "2020-03-02T03:15:10+01:00",
-  "sha256": "1gvfl80vpb2wi4v5qnllfs8z0kzj6bmyk4aqxk6n0z2g41yxpf18",
-  "fetchSubmodules": false
-}

--- a/nix/nixpkgs.nix
+++ b/nix/nixpkgs.nix
@@ -1,16 +1,10 @@
 let
-  nixpkgsSrc = builtins.fromJSON (builtins.readFile ./nixpkgs.json);
-  nixpkgs = builtins.fetchTarball {
-    url = "https://github.com/NixOS/nixpkgs/archive/${nixpkgsSrc.rev}.tar.gz";
-    inherit (nixpkgsSrc) sha256;
-  };
   haskellNixSrc = builtins.fromJSON (builtins.readFile ./haskell-nix.json);
   haskellNix = import (
     builtins.fetchTarball {
       url = "https://github.com/input-output-hk/haskell.nix/archive/${haskellNixSrc.rev}.tar.gz";
       inherit (haskellNixSrc) sha256;
     }
-  );
-  pkgs = import nixpkgs haskellNix;
+  ) {};
 in
-pkgs
+import haskellNix.sources.nixpkgs-2003 haskellNix.nixpkgsArgs

--- a/nix/update.nix
+++ b/nix/update.nix
@@ -12,7 +12,5 @@ writeScript "update.sh" ''
 
   nixprefetchgit="${nix-prefetch-git}/bin/nix-prefetch-git"
 
-  channel='nixos-20.03'
-  $nixprefetchgit https://github.com/nixos/nixpkgs-channels.git --rev "refs/heads/$channel" > ./nix/nixpkgs.json
   $nixprefetchgit https://github.com/input-output-hk/haskell.nix.git --rev "refs/heads/master" > ./nix/haskell-nix.json
 ''

--- a/stack-ghc881.yaml
+++ b/stack-ghc881.yaml
@@ -1,5 +1,0 @@
-resolver: nightly-2020-01-21 # lts-15.0 is not yet available through haskell.nix
-packages:
-  - "."
-nix:
-  path: [nixpkgs=./nix/nixpkgs-stack.nix]

--- a/stack-ghc883.yaml
+++ b/stack-ghc883.yaml
@@ -1,0 +1,5 @@
+resolver: lts-15.6
+packages:
+  - "."
+nix:
+  path: [nixpkgs=./nix/nixpkgs-stack.nix]

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,1 +1,1 @@
-stack-ghc881.yaml
+stack-ghc883.yaml


### PR DESCRIPTION
... and use the nixpkgs pin from haskell.nix to simplify the setup.