### PR TITLE
(doc) monad-bayes is in lts-16.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # monad-bayes
 
 [![Hackage](https://img.shields.io/hackage/v/monad-bayes.svg)](https://hackage.haskell.org/package/monad-bayes)
-[![Stackage Nightly](http://stackage.org/package/monad-bayes/badge/nightly)](http://stackage.org/nightly/package/monad-bayes)
+[![Stackage](http://stackage.org/package/monad-bayes/badge/lts)](http://stackage.org/lts/package/monad-bayes)
 [![Hackage Deps](https://img.shields.io/hackage-deps/v/monad-bayes.svg)](http://packdeps.haskellers.com/reverse/monad-bayes)
 [![Build status](https://badge.buildkite.com/147af088063e8619fcf52ecf93fa7dd3353a2e8a252ef8e6ad.svg?branch=master)](https://buildkite.com/tweag-1/monad-bayes)
 


### PR DESCRIPTION
**[Preview](https://github.com/tweag/monad-bayes/blob/lts-badge/README.md)**.