### PR TITLE
A draft for discussion

### DIFF
--- a/benchmark/SSM.hs
+++ b/benchmark/SSM.hs
@@ -9,21 +9,26 @@ import Control.Monad.Bayes.Sampler
 import Control.Monad.Bayes.Weighted
 import Control.Monad.IO.Class
 import NonlinearSSM
+import System.Random.Stateful
 
 main :: IO ()
-main = sampleIO $ do
-  let t = 5
-  dat <- generateData t
-  let ys = map snd dat
-  liftIO $ print "SMC"
-  smcRes <- runPopulation $ smcMultinomial t 10 (param >>= model ys)
-  liftIO $ print $ show smcRes
-  liftIO $ print "RM-SMC"
-  smcrmRes <- runPopulation $ rmsmcLocal t 10 10 (param >>= model ys)
-  liftIO $ print $ show smcrmRes
-  liftIO $ print "PMMH"
-  pmmhRes <- prior $ pmmh 2 t 3 param (model ys)
-  liftIO $ print $ show pmmhRes
-  liftIO $ print "SMC2"
-  smc2Res <- runPopulation $ smc2 t 3 2 1 param (model ys)
-  liftIO $ print $ show smc2Res
+main = do
+  (smcRes, smcrmRes, pmmhRes, smc2Res) <-
+    newIOGenM (mkStdGen 1729) >>=
+    (sampleIOwith $ do
+        let t = 5
+        dat <- generateData t
+        let ys = map snd dat
+        smcRes <- runPopulation $ smcMultinomial t 10 (param >>= model ys)
+        smcrmRes <- runPopulation $ rmsmcLocal t 10 10 (param >>= model ys)
+        pmmhRes <- prior $ pmmh 2 t 3 param (model ys)
+        smc2Res <- runPopulation $ smc2 t 3 2 1 param (model ys)
+        return (smcRes, smcrmRes, pmmhRes, smc2Res))
+  print "SMC"
+  print $ show smcRes
+  print "RM-SMC"
+  print $ show smcrmRes
+  print "PMMH"
+  print $ show pmmhRes
+  print "SMC2"
+  print $ show smc2Res

--- a/benchmark/Single.hs
+++ b/benchmark/Single.hs
@@ -10,7 +10,8 @@ import qualified HMM
 import qualified LDA
 import qualified LogReg
 import Options.Applicative
-import System.Random.MWC (createSystemRandom)
+import System.Random.MWC (createSystemRandom, create)
+import Control.Monad.ST (runST)
 
 data Model = LR Int | HMM Int | LDA (Int, Int)
   deriving (Show, Read)
@@ -29,16 +30,14 @@ getModel model = (size model, program model)
     size (LR n) = n
     size (HMM n) = n
     size (LDA (d, w)) = d * w
-    synthesize :: SamplerST a -> (a -> b) -> b
-    synthesize dataGen prog = prog (sampleSTfixed dataGen)
-    program (LR n) = show <$> synthesize (LogReg.syntheticData n) LogReg.logisticRegression
-    program (HMM n) = show <$> synthesize (HMM.syntheticData n) HMM.hmm
-    program (LDA (d, w)) = show <$> synthesize (LDA.syntheticData d w) LDA.lda
+    program (LR n) = show <$> (LogReg.logisticRegression (runST $ create >>= sampleSTwith (LogReg.syntheticData n)))
+    program (HMM n) = show <$> (HMM.hmm (runST $ create >>= sampleSTwith (HMM.syntheticData n)))
+    program (LDA (d, w)) = show <$> (LDA.lda (runST $ create >>= sampleSTwith (LDA.syntheticData d w)))
 
 data Alg = SMC | MH | RMSMC
   deriving (Read, Show)
 
-runAlg :: Model -> Alg -> SamplerIO String
+runAlg :: Model -> Alg -> SamplerIO g String
 runAlg model alg =
   case alg of
     SMC ->

--- a/benchmark/Speed.hs
+++ b/benchmark/Speed.hs
@@ -46,7 +46,7 @@ instance Show Alg where
   show (SMC n) = "SMC" ++ show n
   show (RMSMC n t) = "RMSMC" ++ show n ++ "-" ++ show t
 
-runAlg :: Model -> Alg -> SamplerIO String
+runAlg :: Model -> Alg -> SamplerIO g String
 runAlg model (MH n) = show <$> prior (mh n (buildModel model))
 runAlg model (SMC n) = show <$> runPopulation (smcSystematic (modelLength model) n (buildModel model))
 runAlg model (RMSMC n t) = show <$> runPopulation (rmsmcLocal (modelLength model) n t (buildModel model))

--- a/monad-bayes.cabal
+++ b/monad-bayes.cabal
@@ -147,6 +147,7 @@ benchmark ssm-bench
   build-depends:
       base
     , monad-bayes
+    , random
 
 benchmark speed-bench
   type:             exitcode-stdio-1.0

--- a/monad-bayes.cabal
+++ b/monad-bayes.cabal
@@ -61,6 +61,7 @@ library
     , monad-coroutine  ^>=0.9.0
     , mtl              ^>=2.2.2
     , mwc-random       >=0.13.6 && <0.16
+    , random
     , safe             ^>=0.3.17
     , statistics       >=0.14.0 && <0.17
     , transformers     ^>=0.5.2
@@ -125,6 +126,7 @@ test-suite monad-bayes-test
     , monad-bayes
     , mtl
     , QuickCheck
+    , random
     , transformers
     , vector
 

--- a/src/Control/Monad/Bayes/Sampler.hs
+++ b/src/Control/Monad/Bayes/Sampler.hs
@@ -19,14 +19,14 @@
 -- transformer to obtain a 'MonadInfer' that can execute probabilistic models.
 module Control.Monad.Bayes.Sampler
   ( SamplerIO,
-    sampleIO,
-    sampleIOfixed,
+    -- sampleIO,
+    -- sampleIOfixed,
     sampleIOwith,
     Seed,
     SamplerST (SamplerST),
     runSamplerST,
-    sampleST,
-    sampleSTfixed,
+    -- sampleST,
+    -- sampleSTfixed,
   )
 where
 
@@ -70,8 +70,8 @@ sampleIOfixed :: SamplerIO g a -> IO a
 sampleIOfixed (SamplerIO m) = undefined -- create >>= runReaderT m
 
 -- | Like 'sampleIO' but with a custom pseudo-random number generator.
-sampleIOwith :: SamplerIO g a -> GenIO -> IO a
-sampleIOwith (SamplerIO m) = undefined -- runReaderT m
+sampleIOwith :: SR.StatefulGen r IO => SamplerIO r a -> r -> IO a
+sampleIOwith (SamplerIO m) = runReaderT m
 
 instance MonadSample (SamplerIO g) where
   random = SamplerIO ((\s -> ask >>= lift . s) (uniformRM (0, 1))) -- FIXME: There is a special function for this

--- a/src/Control/Monad/Bayes/Sampler.hs
+++ b/src/Control/Monad/Bayes/Sampler.hs
@@ -2,6 +2,10 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE RankNTypes #-}
 
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
 -- |
 -- Module      : Control.Monad.Bayes.Sampler
 -- Description : Pseudo-random sampling monads
@@ -34,76 +38,90 @@ import Control.Monad.Trans.Reader (ReaderT, ask, mapReaderT, runReaderT)
 import System.Random.MWC
 import qualified System.Random.MWC.Distributions as MWC
 
+import Data.Void
+import qualified System.Random.Stateful as SR
+
 -- | An 'IO' based random sampler using the MWC-Random package.
-newtype SamplerIO a = SamplerIO (ReaderT GenIO IO a)
-  deriving newtype (Functor, Applicative, Monad, MonadIO)
+newtype SamplerIO g a = SamplerIO (SR.StatefulGen g IO => ReaderT g IO a)
+
+instance Functor (SamplerIO g) where
+  fmap f (SamplerIO s) = SamplerIO $ fmap f s
+
+instance Applicative (SamplerIO g) where
+  pure x = SamplerIO $ pure x
+  (SamplerIO f) <*> (SamplerIO x) = SamplerIO $ f <*> x
+
+runSamplerIO :: SR.StatefulGen g IO => SamplerIO g a -> ReaderT g IO a
+runSamplerIO (SamplerIO s) = s
+
+instance Monad (SamplerIO g) where
+  (SamplerIO x) >>= f = SamplerIO $ x >>= runSamplerIO . f
 
 -- | Initialize a pseudo-random number generator using randomness supplied by
 -- the operating system.
 -- For efficiency this operation should be applied at the very end, ideally
 -- once per program.
-sampleIO :: SamplerIO a -> IO a
-sampleIO (SamplerIO m) = createSystemRandom >>= runReaderT m
+sampleIO :: SamplerIO g a -> IO a
+sampleIO (SamplerIO m) = undefined -- createSystemRandom >>= runReaderT m
 
 -- | Like 'sampleIO', but with a fixed random seed.
 -- Useful for reproducibility.
-sampleIOfixed :: SamplerIO a -> IO a
-sampleIOfixed (SamplerIO m) = create >>= runReaderT m
+sampleIOfixed :: SamplerIO g a -> IO a
+sampleIOfixed (SamplerIO m) = undefined -- create >>= runReaderT m
 
 -- | Like 'sampleIO' but with a custom pseudo-random number generator.
-sampleIOwith :: SamplerIO a -> GenIO -> IO a
-sampleIOwith (SamplerIO m) = runReaderT m
+sampleIOwith :: SamplerIO g a -> GenIO -> IO a
+sampleIOwith (SamplerIO m) = undefined -- runReaderT m
 
-fromSamplerST :: SamplerST a -> SamplerIO a
-fromSamplerST (SamplerST m) = SamplerIO $ mapReaderT stToIO m
-
-instance MonadSample SamplerIO where
-  random = fromSamplerST random
+instance MonadSample (SamplerIO g) where
+  random = SamplerIO ((\s -> ask >>= lift . s) (uniformRM (0, 1))) -- FIXME: There is a special function for this
 
 -- | An 'ST' based random sampler using the @mwc-random@ package.
-newtype SamplerST a = SamplerST (forall s. ReaderT (GenST s) (ST s) a)
+newtype SamplerST g a = SamplerST (forall s. SR.StatefulGen g (ST s) => ReaderT g (ST s) a)
 
-runSamplerST :: SamplerST a -> ReaderT (GenST s) (ST s) a
+runSamplerST :: SR.StatefulGen g (ST s) => SamplerST g a -> ReaderT g (ST s) a
 runSamplerST (SamplerST s) = s
 
-instance Functor SamplerST where
+instance Functor (SamplerST g) where
   fmap f (SamplerST s) = SamplerST $ fmap f s
 
-instance Applicative SamplerST where
+instance Applicative (SamplerST g)where
   pure x = SamplerST $ pure x
   (SamplerST f) <*> (SamplerST x) = SamplerST $ f <*> x
 
-instance Monad SamplerST where
+instance Monad (SamplerST g) where
   (SamplerST x) >>= f = SamplerST $ x >>= runSamplerST . f
 
 -- | Run the sampler with a supplied seed.
 -- Note that 'State Seed' is much less efficient than 'SamplerST' for composing computation.
-sampleST :: SamplerST a -> State Seed a
+sampleST :: SamplerST g a -> State Seed a
 sampleST (SamplerST s) =
-  state $ \seed -> runST $ do
-    gen <- restore seed
-    y <- runReaderT s gen
-    finalSeed <- save gen
-    return (y, finalSeed)
+  undefined
+  -- state $ \seed -> runST $ do
+  --   gen <- restore seed
+  --   y <- runReaderT s gen
+  --   finalSeed <- save gen
+  --   return (y, finalSeed)
 
 -- | Run the sampler with a fixed random seed.
-sampleSTfixed :: SamplerST a -> a
+sampleSTfixed :: SamplerST g a -> a
 sampleSTfixed (SamplerST s) = runST $ do
-  gen <- create
-  runReaderT s gen
+  undefined
+  -- gen <- create
+  -- runReaderT s gen
 
 -- | Convert a distribution supplied by @mwc-random@.
-fromMWC :: (forall s. GenST s -> ST s a) -> SamplerST a
-fromMWC s = SamplerST $ ask >>= lift . s
+fromMWC :: (g -> (ST s) a) -> ReaderT g (ST s) a
+fromMWC = (\s -> ask >>= lift . s)
 
-instance MonadSample SamplerST where
-  random = fromMWC System.Random.MWC.uniform
+instance MonadSample (SamplerST g) where
+  random = SamplerST (fromMWC (uniformRM (0, 1))) -- FIXME: There is a special function for this
 
-  uniform a b = fromMWC $ uniformR (a, b)
-  normal m s = fromMWC $ MWC.normal m s
-  gamma shape scale = fromMWC $ MWC.gamma shape scale
-  beta a b = fromMWC $ MWC.beta a b
+  uniform a b       = SamplerST (fromMWC $ uniformRM (a, b))
+  normal m s        = SamplerST (fromMWC (MWC.normal m s))
+  gamma shape scale = SamplerST (fromMWC $ MWC.gamma shape scale)
+  beta a b          = SamplerST (fromMWC $ MWC.beta a b)
 
-  bernoulli p = fromMWC $ MWC.bernoulli p
-  categorical ps = fromMWC $ MWC.categorical ps
-  geometric p = fromMWC $ MWC.geometric0 p
+  bernoulli p    = SamplerST (fromMWC $ MWC.bernoulli p)
+  categorical ps = SamplerST (fromMWC $ MWC.categorical ps)
+  geometric p    = SamplerST (fromMWC $ MWC.geometric0 p)

--- a/src/Control/Monad/Bayes/Sampler.hs
+++ b/src/Control/Monad/Bayes/Sampler.hs
@@ -27,6 +27,7 @@ module Control.Monad.Bayes.Sampler
     runSamplerST,
     -- sampleST,
     -- sampleSTfixed,
+    sampleSTwith
   )
 where
 
@@ -110,7 +111,10 @@ sampleSTfixed (SamplerST s) = runST $ do
   -- gen <- create
   -- runReaderT s gen
 
--- | Convert a distribution supplied by @mwc-random@.
+-- | Like 'sampleST' but with a custom pseudo-random number generator.
+sampleSTwith :: SR.StatefulGen r (ST s) => SamplerST r a -> r -> ST s a
+sampleSTwith (SamplerST s) = runReaderT s
+
 fromMWC :: (g -> (ST s) a) -> ReaderT g (ST s) a
 fromMWC = (\s -> ask >>= lift . s)
 

--- a/test/TestInference.hs
+++ b/test/TestInference.hs
@@ -10,6 +10,7 @@ import Control.Monad.Bayes.Population
 import Control.Monad.Bayes.Sampler
 import Data.AEq
 import Numeric.Log
+import System.Random.Stateful
 import Sprinkler
 
 sprinkler :: MonadInfer m => m Bool
@@ -18,18 +19,22 @@ sprinkler = Sprinkler.soft
 -- | Count the number of particles produced by SMC
 checkParticles :: Int -> Int -> IO Int
 checkParticles observations particles =
-  sampleIOfixed (fmap length (runPopulation $ smcMultinomial observations particles Sprinkler.soft))
+  newIOGenM (mkStdGen 1729) >>=
+  sampleIOwith (fmap length (runPopulation $ smcMultinomial observations particles Sprinkler.soft))
 
 checkParticlesSystematic :: Int -> Int -> IO Int
 checkParticlesSystematic observations particles =
-  sampleIOfixed (fmap length (runPopulation $ smcSystematic observations particles Sprinkler.soft))
+  newIOGenM (mkStdGen 1729) >>=
+  sampleIOwith (fmap length (runPopulation $ smcSystematic observations particles Sprinkler.soft))
 
 checkParticlesStratified :: Int -> Int -> IO Int
 checkParticlesStratified observations particles =
-  sampleIOfixed (fmap length (runPopulation $ smcStratified observations particles Sprinkler.soft))
+  newIOGenM (mkStdGen 1729) >>=
+  sampleIOwith (fmap length (runPopulation $ smcStratified observations particles Sprinkler.soft))
 
 checkTerminateSMC :: IO [(Bool, Log Double)]
-checkTerminateSMC = sampleIOfixed (runPopulation $ smcMultinomial 2 5 sprinkler)
+checkTerminateSMC = newIOGenM (mkStdGen 1729) >>=
+                    sampleIOwith (runPopulation $ smcMultinomial 2 5 sprinkler)
 
 checkPreserveSMC :: Bool
 checkPreserveSMC =

--- a/test/TestPopulation.hs
+++ b/test/TestPopulation.hs
@@ -5,16 +5,19 @@ import Control.Monad.Bayes.Enumerator
 import Control.Monad.Bayes.Population as Population
 import Control.Monad.Bayes.Sampler
 import Data.AEq
+import System.Random.Stateful
 import Sprinkler
 
 weightedSampleSize :: MonadSample m => Population m a -> m Int
 weightedSampleSize = fmap length . runPopulation
 
 popSize :: IO Int
-popSize = sampleIOfixed $ weightedSampleSize $ spawn 5 >> sprinkler
+popSize = newIOGenM (mkStdGen 1729) >>=
+          sampleIOwith (weightedSampleSize $ spawn 5 >> sprinkler)
 
 manySize :: IO Int
-manySize = sampleIOfixed $ weightedSampleSize $ spawn 5 >> sprinkler >> spawn 3
+manySize = newIOGenM (mkStdGen 1729) >>=
+           sampleIOwith (weightedSampleSize $ spawn 5 >> sprinkler >> spawn 3)
 
 sprinkler :: MonadInfer m => m Bool
 sprinkler = Sprinkler.soft

--- a/test/TestWeighted.hs
+++ b/test/TestWeighted.hs
@@ -9,6 +9,7 @@ import Control.Monad.State
 import Data.AEq
 import Data.Bifunctor (second)
 import Numeric.Log
+import System.Random.Stateful
 
 model :: MonadInfer m => m (Int, Double)
 model = do
@@ -22,7 +23,8 @@ result :: MonadSample m => m ((Int, Double), Double)
 result = second (exp . ln) <$> runWeighted model
 
 passed :: IO Bool
-passed = fmap check (sampleIOfixed result)
+passed = do stdGen <- newIOGenM (mkStdGen 1729)
+            fmap check (sampleIOwith result stdGen)
 
 check :: ((Int, Double), Double) -> Bool
 check ((0, 1), 1) = True


### PR DESCRIPTION
@reubenharry I have put a draft here for us to think about. I haven't finished the transition as

1. Skolem variables escaping their scope in the `ST` monad (not a problem with only one RNG as unification sorts that out).
2. What do we do about defaults? I think for now we should use the RNG from `random` (*not* from `mwc-random`) as it is a lot faster. We can think about enhancing the interface later to provide more flexibility for the user (to choose their favourite RNG). I think this also sort out the Skolem problem.

Thoughts?