### PR TITLE
Fix website link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-# [Monad-Bayes](https://monad-bayes-site.netlify.app/about.html)
+# [Monad-Bayes](https://monad-bayes.netlify.app)
 
 <!-- [![Hackage](https://img.shields.io/hackage/v/monad-bayes.svg)](https://hackage.haskell.org/package/monad-bayes)
 [![Stackage](http://stackage.org/package/monad-bayes/badge/lts)](http://stackage.org/lts/package/monad-bayes)
 [![Hackage Deps](https://img.shields.io/hackage-deps/v/monad-bayes.svg)](http://packdeps.haskellers.com/reverse/monad-bayes)
 [![Build status](https://badge.buildkite.com/147af088063e8619fcf52ecf93fa7dd3353a2e8a252ef8e6ad.svg?branch=master)](https://buildkite.com/tweag-1/monad-bayes) -->
 
-[See the website](https://monad-bayes-site.netlify.app/about.html) for an overview of the documentation, library, tutorials, examples (and a link to this very source code). 
+[See the website](https://monad-bayes.netlify.app) for an overview of the documentation, library, tutorials, examples (and a link to this very source code). 
 
 <!-- Monad-Bayes is a library for **probabilistic programming in Haskell**. The emphasis is on composition of inference algorithms, and is implemented in terms of monad transformers. -->
 


### PR DESCRIPTION
Stumbled up this today and the website link seemed to be incorrect. I guessed it was `https://monad-bayes.netlify.app/` instead of `https://monad-bayes-site.netlify.app/` and that was true haha.

There doesn't seem to be be an `/about.html` page anymore though, so I dropped it from the link.