### PR TITLE
Port to brick versions >= 1.0

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -61,7 +61,35 @@
           "^test.*$"
           "^.*\.md"
         ];
-        monad-bayes = pkgs.haskell.packages.ghc902.callCabal2nixWithOptions "monad-bayes" src "--benchmark" {};
+        monad-bayes = pkgs.haskell.packages.ghc902.developPackage {
+          name = "monad-bayes";
+          root = src;
+
+          # Remove this override when bumping nixpkgs
+          source-overrides = {
+            vty = pkgs.fetchzip {
+              url = "mirror://hackage/vty-5.37/vty-5.37.tar.gz";
+              sha256 = "sha256-OOrJBi/mSIyaibgObrp6NmUTWxRu9pxmjAL0EuPV9wY=";
+            };
+
+            text-zipper = pkgs.fetchzip {
+              url = "mirror://hackage/text-zipper-0.12/text-zipper-0.12.tar.gz";
+              sha256 = "sha256-P2/UHuG3UuSN7G31DyYvyUWSyIj2YXAOmjGkHtTaP8o=";
+            };
+
+            bimap = pkgs.fetchzip {
+              url = "mirror://hackage/bimap-0.5.0/bimap-0.5.0.tar.gz";
+              sha256 = "sha256-pbw+xg9Qz/c7YoXAJg8SR11RJGmgMw5hhnzKv+bGK9w=";
+            };
+
+            brick = pkgs.fetchzip {
+              url = "mirror://hackage/brick-1.4/brick-1.4.tar.gz";
+              sha256 = "sha256-KDa7RVQQPpinkJ0aKsYP0E50pn2auEIP38l6Uk7GmmE=";
+            };
+          };
+
+          cabal2nixOptions = "--benchmark";
+        };
 
         iHaskell = pkgs.kernels.iHaskellWith {
           # Identifier that will appear on the Jupyter interface.

--- a/monad-bayes.cabal
+++ b/monad-bayes.cabal
@@ -65,7 +65,7 @@ library
   default-language:   Haskell2010
   build-depends:
       base             >=4.11   && <4.17
-    , brick
+    , brick            >=1.0    && <2.0
     , containers       >=0.5.10 && <0.7
     , foldl
     , free             >=5.0.2  && <5.2


### PR DESCRIPTION
This PR contains the necessary changes for supporting `brick` versions between 1.0 and 2.0, fixing #221.

Alternatively, the `brick` version would need to be constrained to be 0.73 or less. If this would be preferably, please just close this PR.
