### PR TITLE
Add bus example and necessary Poisson pdf

### DIFF
--- a/src/Control/Monad/Bayes/Class.hs
+++ b/src/Control/Monad/Bayes/Class.hs
@@ -58,6 +58,7 @@ module Control.Monad.Bayes.Class
     discrete,
     normalPdf,
     Bayesian (..),
+    poissonPdf,
     posterior,
     priorPredictive,
     posteriorPredictive,
@@ -96,7 +97,7 @@ import Data.Vector.Generic as VG (Vector, map, mapM, null, sum, (!))
 import Numeric.Log (Log (..))
 import Statistics.Distribution
   ( ContDistr (logDensity, quantile),
-    DiscreteDistr (probability),
+    DiscreteDistr (probability, logProbability),
   )
 import Statistics.Distribution.Beta (betaDistr)
 import Statistics.Distribution.Gamma (gammaDistr)
@@ -284,6 +285,9 @@ normalPdf ::
   -- | relative likelihood of observing sample x in \(\mathcal{N}(\mu, \sigma^2)\)
   Log Double
 normalPdf mu sigma x = Exp $ logDensity (normalDistr mu sigma) x
+
+poissonPdf :: Double -> Integer -> Log Double
+poissonPdf rate n = Exp $ logProbability (Poisson.poisson rate) (fromIntegral n)
 
 -- | multivariate normal
 mvNormal :: MonadDistribution m => V.Vector Double -> Matrix Double -> m (V.Vector Double)

--- a/src/Control/Monad/Bayes/Class.hs
+++ b/src/Control/Monad/Bayes/Class.hs
@@ -97,7 +97,7 @@ import Data.Vector.Generic as VG (Vector, map, mapM, null, sum, (!))
 import Numeric.Log (Log (..))
 import Statistics.Distribution
   ( ContDistr (logDensity, quantile),
-    DiscreteDistr (probability, logProbability),
+    DiscreteDistr (logProbability, probability),
   )
 import Statistics.Distribution.Beta (betaDistr)
 import Statistics.Distribution.Gamma (gammaDistr)

--- a/src/Control/Monad/Bayes/Traced/Static.hs
+++ b/src/Control/Monad/Bayes/Traced/Static.hs
@@ -83,7 +83,6 @@ mhStep (Traced m d) = Traced m d'
     d' = d >>= mhTransFree m
 
 -- $setup
--- >>> let z = 23 :: Int
 -- >>> import Control.Monad.Bayes.Class
 -- >>> import Control.Monad.Bayes.Sampler.Strict
 -- >>> import Control.Monad.Bayes.Weighted

--- a/src/Control/Monad/Bayes/Traced/Static.hs
+++ b/src/Control/Monad/Bayes/Traced/Static.hs
@@ -90,6 +90,13 @@ mhStep (Traced m d) = Traced m d'
 -- | Full run of the Trace Metropolis-Hastings algorithm with a specified
 -- number of steps. Newest samples are at the head of the list.
 --
+-- For example:
+--
+-- * I have forgotten what day it is.
+-- * There are ten buses per hour in the week and three buses per hour at the weekend.
+-- * I observe four buses in a given hour.
+-- * What is the probability that it is the weekend?
+--
 -- >>> :{
 --  let
 --    bus = do x <- bernoulli (2/7)
@@ -102,6 +109,8 @@ mhStep (Traced m d) = Traced m d'
 --  in mhRunBusSingleObs
 -- :}
 -- [True,True,True]
+--
+-- Of course, it will need to be run more than twice to get a reasonable estimate.
 mh :: MonadDistribution m => Int -> Traced m a -> m [a]
 mh n (Traced m d) = fmap (map output . NE.toList) (f n)
   where

--- a/src/Control/Monad/Bayes/Traced/Static.hs
+++ b/src/Control/Monad/Bayes/Traced/Static.hs
@@ -82,8 +82,27 @@ mhStep (Traced m d) = Traced m d'
   where
     d' = d >>= mhTransFree m
 
+-- $setup
+-- >>> let z = 23 :: Int
+-- >>> import Control.Monad.Bayes.Class
+-- >>> import Control.Monad.Bayes.Sampler.Strict
+-- >>> import Control.Monad.Bayes.Weighted
+
 -- | Full run of the Trace Metropolis-Hastings algorithm with a specified
 -- number of steps. Newest samples are at the head of the list.
+--
+-- >>> :{
+--  let
+--    bus = do x <- bernoulli (2/7)
+--             let rate = if x then 3 else 10
+--             factor $ poissonPdf rate 4
+--             return x
+--    mhRunBusSingleObs = do
+--      let nSamples = 2
+--      sampleIOfixed $ unweighted $ mh nSamples bus
+--  in mhRunBusSingleObs
+-- :}
+-- [True,True,True]
 mh :: MonadDistribution m => Int -> Traced m a -> m [a]
 mh n (Traced m d) = fmap (map output . NE.toList) (f n)
   where


### PR DESCRIPTION
I took Sam Staton's bus example from https://www.cs.uoregon.edu/research/summerschool/summer19/topics.php#Staton and added it as an example. This required adding the Poisson pmf but I seem to have called it poissonPdf because that is what Sam did. Apart from naming, I think this is uncontroversial.