### PR TITLE
Free list transformer to replace deprecated ListT

### DIFF
--- a/docs/docs/usage.md
+++ b/docs/docs/usage.md
@@ -328,18 +328,20 @@ Summary of key info on `PopulationT`:
 - `instance MonadFactor m => instance MonadFactor (PopulationT m)`
 
 ```haskell
-newtype PopulationT m a = PopulationT (WeightedT (ListT m) a)
+newtype PopulationT m a = PopulationT (WeightedT (FreeT [] m) a)
 ```
 
-So:
+The `FreeT []` construction is for branching our probabilistic program into different branches,
+corresponding to different choices of a random variable.
+
+It is interpreted, using `runPopulationT`, to:
 
 ```haskell
-PopulationT m a ~ m [Log Double -> (a, Log Double)]
+m [(a, Log Double)]
 ```
 
-Note that while `ListT` isn't in general a valid monad transformer, we're not requiring it to be one here.
-
-`Population` is used to represent a collection of particles (in the statistical sense), along with their weights.
+This shows that `Population` is used to compute a collection of particles (in the statistical sense), along with their weights.
+Each `a` corresponds to one particle, and `Log Double` is the type of its weight.
 
 There are several useful functions associated with it:
 

--- a/monad-bayes.cabal
+++ b/monad-bayes.cabal
@@ -63,21 +63,21 @@ common deps
     , scientific       ^>=0.3
     , statistics       >=0.14.0  && <0.17
     , text             >=1.2     && <2.1
+    , transformers     ^>=0.5.6
     , vector           >=0.12.0  && <0.14
     , vty              ^>=5.38
 
 common test-deps
   build-depends:
     , abstract-par          ^>=0.3
-    , criterion             >=1.5    && <1.7
+    , criterion             >=1.5   && <1.7
     , directory             ^>=1.3
     , hspec                 ^>=2.11
     , monad-bayes
-    , optparse-applicative  >=0.17   && <0.19
+    , optparse-applicative  >=0.17  && <0.19
     , process               ^>=1.6
     , QuickCheck            ^>=2.14
-    , time                  >=1.9    && <1.13
-    , transformers          ^>=0.5.6
+    , time                  >=1.9   && <1.13
     , typed-process         ^>=0.2
 
   autogen-modules: Paths_monad_bayes

--- a/monad-bayes.cabal
+++ b/monad-bayes.cabal
@@ -101,6 +101,7 @@ library
     Control.Monad.Bayes.Inference.TUI
     Control.Monad.Bayes.Integrator
     Control.Monad.Bayes.Population
+    Control.Monad.Bayes.Population.Applicative
     Control.Monad.Bayes.Sampler.Lazy
     Control.Monad.Bayes.Sampler.Strict
     Control.Monad.Bayes.Sequential.Coroutine

--- a/monad-bayes.cabal
+++ b/monad-bayes.cabal
@@ -86,6 +86,7 @@ common test-deps
 library
   import:             deps
   exposed-modules:
+    Control.Applicative.List
     Control.Monad.Bayes.Class
     Control.Monad.Bayes.Density.Free
     Control.Monad.Bayes.Density.State
@@ -114,8 +115,11 @@ library
   other-modules:      Control.Monad.Bayes.Traced.Common
   default-language:   Haskell2010
   default-extensions:
+    ApplicativeDo
     BlockArguments
+    DerivingStrategies
     FlexibleContexts
+    GeneralizedNewtypeDeriving
     ImportQualifiedPost
     LambdaCase
     OverloadedStrings

--- a/src/Control/Applicative/List.hs
+++ b/src/Control/Applicative/List.hs
@@ -1,0 +1,17 @@
+module Control.Applicative.List where
+
+-- base
+
+import Control.Applicative
+import Data.Functor.Compose
+
+-- | _Applicative_ transformer adding a list/nondeterminism/choice effect.
+--   It is not a valid monad transformer, but it is a valid 'Applicative'.
+newtype ListT m a = ListT {getListT :: Compose [] m a}
+  deriving newtype (Functor, Applicative, Alternative)
+
+lift :: m a -> ListT m a
+lift = ListT . Compose . pure
+
+runListT :: ListT m a -> [m a]
+runListT = getCompose . getListT

--- a/src/Control/Applicative/List.hs
+++ b/src/Control/Applicative/List.hs
@@ -1,17 +1,38 @@
+{-# LANGUAGE StandaloneDeriving #-}
+
 module Control.Applicative.List where
 
 -- base
-
 import Control.Applicative
+-- transformers
+import Control.Monad.Trans.Writer.Strict
 import Data.Functor.Compose
+-- log-domain
+import Numeric.Log (Log)
+
+-- * Applicative ListT
 
 -- | _Applicative_ transformer adding a list/nondeterminism/choice effect.
 --   It is not a valid monad transformer, but it is a valid 'Applicative'.
-newtype ListT m a = ListT {getListT :: Compose [] m a}
+newtype ListT m a = ListT {getListT :: Compose m [] a}
   deriving newtype (Functor, Applicative, Alternative)
 
-lift :: m a -> ListT m a
-lift = ListT . Compose . pure
+lift :: (Functor m) => m a -> ListT m a
+lift = ListT . Compose . fmap pure
 
-runListT :: ListT m a -> [m a]
+runListT :: ListT m a -> m [a]
 runListT = getCompose . getListT
+
+-- * Applicative Population transformer
+
+-- WriterT has to be used instead of WeightedT,
+-- since WeightedT uses StateT under the hood,
+-- which requires a Monad (ListT m) constraint.
+newtype PopulationT m a = PopulationT {getPopulationT :: WriterT (Log Double) (ListT m) a}
+  deriving newtype (Functor, Applicative, Alternative)
+
+runPopulationT :: PopulationT m a -> m [(a, Log Double)]
+runPopulationT = runListT . runWriterT . getPopulationT
+
+fromWeightedList :: m [(a, Log Double)] -> PopulationT m a
+fromWeightedList = PopulationT . WriterT . ListT . Compose

--- a/src/Control/Applicative/List.hs
+++ b/src/Control/Applicative/List.hs
@@ -4,11 +4,7 @@ module Control.Applicative.List where
 
 -- base
 import Control.Applicative
--- transformers
-import Control.Monad.Trans.Writer.Strict
 import Data.Functor.Compose
--- log-domain
-import Numeric.Log (Log)
 
 -- * Applicative ListT
 
@@ -17,22 +13,11 @@ import Numeric.Log (Log)
 newtype ListT m a = ListT {getListT :: Compose m [] a}
   deriving newtype (Functor, Applicative, Alternative)
 
+listT :: m [a] -> ListT m a
+listT = ListT . Compose
+
 lift :: (Functor m) => m a -> ListT m a
 lift = ListT . Compose . fmap pure
 
 runListT :: ListT m a -> m [a]
 runListT = getCompose . getListT
-
--- * Applicative Population transformer
-
--- WriterT has to be used instead of WeightedT,
--- since WeightedT uses StateT under the hood,
--- which requires a Monad (ListT m) constraint.
-newtype PopulationT m a = PopulationT {getPopulationT :: WriterT (Log Double) (ListT m) a}
-  deriving newtype (Functor, Applicative, Alternative)
-
-runPopulationT :: PopulationT m a -> m [(a, Log Double)]
-runPopulationT = runListT . runWriterT . getPopulationT
-
-fromWeightedList :: m [(a, Log Double)] -> PopulationT m a
-fromWeightedList = PopulationT . WriterT . ListT . Compose

--- a/src/Control/Monad/Bayes/Class.hs
+++ b/src/Control/Monad/Bayes/Class.hs
@@ -79,9 +79,9 @@ import Control.Monad (replicateM, when)
 import Control.Monad.Cont (ContT)
 import Control.Monad.Except (ExceptT, lift)
 import Control.Monad.Identity (IdentityT)
-import Control.Monad.List (ListT)
 import Control.Monad.Reader (ReaderT)
 import Control.Monad.State (StateT)
+import Control.Monad.Trans.Free.Ap (FreeT)
 import Control.Monad.Writer (WriterT)
 import Data.Histogram qualified as H
 import Data.Histogram.Fill qualified as H
@@ -390,15 +390,15 @@ instance (MonadFactor m) => MonadFactor (StateT s m) where
 
 instance (MonadMeasure m) => MonadMeasure (StateT s m)
 
-instance (MonadDistribution m) => MonadDistribution (ListT m) where
+instance (Applicative f, (MonadDistribution m)) => MonadDistribution (FreeT f m) where
   random = lift random
   bernoulli = lift . bernoulli
   categorical = lift . categorical
 
-instance (MonadFactor m) => MonadFactor (ListT m) where
+instance (Applicative f, (MonadFactor m)) => MonadFactor (FreeT f m) where
   score = lift . score
 
-instance (MonadMeasure m) => MonadMeasure (ListT m)
+instance (Applicative f, (MonadMeasure m)) => MonadMeasure (FreeT f m)
 
 instance (MonadDistribution m) => MonadDistribution (ContT r m) where
   random = lift random

--- a/src/Control/Monad/Bayes/Class.hs
+++ b/src/Control/Monad/Bayes/Class.hs
@@ -81,7 +81,7 @@ import Control.Monad.Except (ExceptT, lift)
 import Control.Monad.Identity (IdentityT)
 import Control.Monad.Reader (ReaderT)
 import Control.Monad.State (StateT)
-import Control.Monad.Trans.Free.Ap (FreeT)
+import Control.Monad.Trans.Free (FreeT)
 import Control.Monad.Writer (WriterT)
 import Data.Histogram qualified as H
 import Data.Histogram.Fill qualified as H

--- a/src/Control/Monad/Bayes/Inference/RMSMC.hs
+++ b/src/Control/Monad/Bayes/Inference/RMSMC.hs
@@ -26,6 +26,7 @@ import Control.Monad.Bayes.Inference.SMC
 import Control.Monad.Bayes.Population
   ( PopulationT,
     flatten,
+    single,
     withParticles,
   )
 import Control.Monad.Bayes.Sequential.Coroutine as Seq
@@ -50,7 +51,7 @@ rmsmc ::
   PopulationT m a
 rmsmc (MCMCConfig {..}) (SMCConfig {..}) =
   marginal
-    . S.sequentially (composeCopies numMCMCSteps (TrStat.hoist flatten . mhStep) . TrStat.hoist resampler) numSteps
+    . S.sequentially (composeCopies numMCMCSteps (TrStat.hoist (single . flatten) . mhStep) . TrStat.hoist resampler) numSteps
     . S.hoistFirst (TrStat.hoist (withParticles numParticles))
 
 -- | Resample-move Sequential Monte Carlo with a more efficient
@@ -64,7 +65,7 @@ rmsmcBasic ::
   PopulationT m a
 rmsmcBasic (MCMCConfig {..}) (SMCConfig {..}) =
   TrBas.marginal
-    . S.sequentially (TrBas.hoist flatten . composeCopies numMCMCSteps (TrBas.hoist flatten . TrBas.mhStep) . TrBas.hoist resampler) numSteps
+    . S.sequentially (TrBas.hoist (single . flatten) . composeCopies numMCMCSteps (TrBas.hoist (single . flatten) . TrBas.mhStep) . TrBas.hoist resampler) numSteps
     . S.hoistFirst (TrBas.hoist (withParticles numParticles))
 
 -- | A variant of resample-move Sequential Monte Carlo
@@ -79,7 +80,7 @@ rmsmcDynamic ::
   PopulationT m a
 rmsmcDynamic (MCMCConfig {..}) (SMCConfig {..}) =
   TrDyn.marginal
-    . S.sequentially (TrDyn.freeze . composeCopies numMCMCSteps (TrDyn.hoist flatten . TrDyn.mhStep) . TrDyn.hoist resampler) numSteps
+    . S.sequentially (TrDyn.freeze . composeCopies numMCMCSteps (TrDyn.hoist (single . flatten) . TrDyn.mhStep) . TrDyn.hoist resampler) numSteps
     . S.hoistFirst (TrDyn.hoist (withParticles numParticles))
 
 -- | Apply a function a given number of times.

--- a/src/Control/Monad/Bayes/Inference/RMSMC.hs
+++ b/src/Control/Monad/Bayes/Inference/RMSMC.hs
@@ -51,8 +51,8 @@ rmsmc ::
   PopulationT m a
 rmsmc (MCMCConfig {..}) (SMCConfig {..}) =
   marginal
-    . S.sequentially (composeCopies numMCMCSteps (TrStat.hoist (single . flatten) . mhStep) . TrStat.hoist resampler) numSteps
-    . S.hoistFirst (TrStat.hoist (withParticles numParticles))
+    . S.sequentially (composeCopies numMCMCSteps (TrStat.hoistModel (single . flatten) . TrStat.hoist (single . flatten) . mhStep) . TrStat.hoist resampler) numSteps
+    . S.hoistFirst (TrStat.hoistModel (single . flatten) . TrStat.hoist (withParticles numParticles))
 
 -- | Resample-move Sequential Monte Carlo with a more efficient
 -- tracing representation.

--- a/src/Control/Monad/Bayes/Population.hs
+++ b/src/Control/Monad/Bayes/Population.hs
@@ -56,7 +56,7 @@ import Control.Monad.Bayes.Weighted
 import Control.Monad.Bayes.Weighted qualified as Weighted
 import Control.Monad.IO.Class
 import Control.Monad.Trans
-import Control.Monad.Trans.Free.Ap
+import Control.Monad.Trans.Free
 import Data.List (unfoldr)
 import Data.List qualified
 import Data.Maybe (catMaybes)

--- a/src/Control/Monad/Bayes/Population.hs
+++ b/src/Control/Monad/Bayes/Population.hs
@@ -34,6 +34,7 @@ module Control.Monad.Bayes.Population
     collapse,
     popAvg,
     withParticles,
+    flatten,
   )
 where
 
@@ -274,3 +275,7 @@ hoist ::
   PopulationT m a ->
   PopulationT n a
 hoist f = PopulationT . Weighted.hoist (hoistFreeT f) . getPopulationT
+
+-- | Flatten all layers of the free structure
+flatten :: (Monad m) => PopulationT m a -> PopulationT m a
+flatten = fromWeightedList . runPopulationT

--- a/src/Control/Monad/Bayes/Population.hs
+++ b/src/Control/Monad/Bayes/Population.hs
@@ -238,7 +238,7 @@ pushEvidence ::
   (MonadFactor m) =>
   PopulationT m a ->
   PopulationT m a
-pushEvidence = hoist applyWeight . extractEvidence
+pushEvidence = single . flatten . hoist applyWeight . extractEvidence
 
 -- | A properly weighted single sample, that is one picked at random according
 -- to the weights, with the sum of all weights.

--- a/src/Control/Monad/Bayes/Population.hs
+++ b/src/Control/Monad/Bayes/Population.hs
@@ -35,10 +35,12 @@ module Control.Monad.Bayes.Population
     popAvg,
     withParticles,
     flatten,
+    single,
   )
 where
 
 import Control.Applicative (Alternative)
+import Control.Applicative.List qualified as ApplicativeListT
 import Control.Arrow (second)
 import Control.Monad (MonadPlus, replicateM)
 import Control.Monad.Bayes.Class
@@ -277,5 +279,11 @@ hoist ::
 hoist f = PopulationT . Weighted.hoist (hoistFreeT f) . getPopulationT
 
 -- | Flatten all layers of the free structure
-flatten :: (Monad m) => PopulationT m a -> PopulationT m a
-flatten = fromWeightedList . runPopulationT
+flatten :: (Monad m) => PopulationT m a -> ApplicativeListT.PopulationT m a
+flatten = ApplicativeListT.fromWeightedList . runPopulationT
+
+-- | Create a population from a single layer of branching computations.
+--
+-- Similar to 'fromWeightedListT'.
+single :: (Monad m) => ApplicativeListT.PopulationT m a -> PopulationT m a
+single = fromWeightedList . ApplicativeListT.runPopulationT

--- a/src/Control/Monad/Bayes/Population.hs
+++ b/src/Control/Monad/Bayes/Population.hs
@@ -37,8 +37,9 @@ module Control.Monad.Bayes.Population
   )
 where
 
+import Control.Applicative (Alternative)
 import Control.Arrow (second)
-import Control.Monad (replicateM)
+import Control.Monad (MonadPlus, replicateM)
 import Control.Monad.Bayes.Class
   ( MonadDistribution (categorical, logCategorical, random, uniform),
     MonadFactor,
@@ -67,7 +68,7 @@ import Prelude hiding (all, sum)
 
 -- | A collection of weighted samples, or particles.
 newtype PopulationT m a = PopulationT {getPopulationT :: WeightedT (FreeT [] m) a}
-  deriving newtype (Functor, Applicative, Monad, MonadIO, MonadDistribution, MonadFactor, MonadMeasure)
+  deriving newtype (Functor, Applicative, Alternative, Monad, MonadIO, MonadPlus, MonadDistribution, MonadFactor, MonadMeasure)
 
 instance MonadTrans PopulationT where
   lift = PopulationT . lift . lift

--- a/src/Control/Monad/Bayes/Population/Applicative.hs
+++ b/src/Control/Monad/Bayes/Population/Applicative.hs
@@ -1,0 +1,29 @@
+-- | 'PopulationT' turns a single sample into a collection of weighted samples.
+--
+-- This module contains an _'Applicative'_ transformer corresponding to the Population monad transformer from the article.
+-- It is based on the old-fashioned 'ListT', which is not a valid monad transformer, but a valid applicative transformer.
+-- The corresponding monad transformer is contained in 'Control.Monad.Bayes.Population'.
+-- One can convert from the monad transformer to the applicative transformer by 'flatten'ing.
+module Control.Monad.Bayes.Population.Applicative where
+
+import Control.Applicative
+import Control.Applicative.List
+import Control.Monad.Trans.Writer.Strict
+import Data.Functor.Compose
+import Numeric.Log (Log)
+
+-- * Applicative Population transformer
+
+-- WriterT has to be used instead of WeightedT,
+-- since WeightedT uses StateT under the hood,
+-- which requires a Monad (ListT m) constraint.
+
+-- | A collection of weighted samples, or particles.
+newtype PopulationT m a = PopulationT {getPopulationT :: WriterT (Log Double) (ListT m) a}
+  deriving newtype (Functor, Applicative, Alternative)
+
+runPopulationT :: PopulationT m a -> m [(a, Log Double)]
+runPopulationT = runListT . runWriterT . getPopulationT
+
+fromWeightedList :: m [(a, Log Double)] -> PopulationT m a
+fromWeightedList = PopulationT . WriterT . listT

--- a/src/Control/Monad/Bayes/Sequential/Coroutine.hs
+++ b/src/Control/Monad/Bayes/Sequential/Coroutine.hs
@@ -22,6 +22,8 @@ module Control.Monad.Bayes.Sequential.Coroutine
     hoist,
     sequentially,
     sis,
+    runSequentialT,
+    extract,
   )
 where
 

--- a/src/Control/Monad/Bayes/Weighted.hs
+++ b/src/Control/Monad/Bayes/Weighted.hs
@@ -24,6 +24,8 @@ module Control.Monad.Bayes.Weighted
   )
 where
 
+import Control.Applicative (Alternative)
+import Control.Monad (MonadPlus)
 import Control.Monad.Bayes.Class
   ( MonadDistribution,
     MonadFactor (..),
@@ -36,7 +38,7 @@ import Numeric.Log (Log)
 -- | Execute the program using the prior distribution, while accumulating likelihood.
 newtype WeightedT m a = WeightedT (StateT (Log Double) m a)
   -- StateT is more efficient than WriterT
-  deriving newtype (Functor, Applicative, Monad, MonadIO, MonadTrans, MonadDistribution)
+  deriving newtype (Functor, Applicative, Alternative, Monad, MonadIO, MonadPlus, MonadTrans, MonadDistribution)
 
 instance (Monad m) => MonadFactor (WeightedT m) where
   score w = WeightedT (modify (* w))


### PR DESCRIPTION
[samples_free_listt.pdf](https://github.com/tweag/monad-bayes/files/10677295/samples_free_listt.pdf)
[samples_master.pdf](https://github.com/tweag/monad-bayes/files/10677296/samples_master.pdf)

Removes the dependency on the deprecated `ListT` in favour of a free monad construction. In fact _improves_ benchmarks significantly!

* [x] Merge #255 first
* [x] Merge #256 first!