### PR TITLE
Allow different versions of GHC on CI

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -40,3 +40,5 @@ jobs:
         run: nix --print-build-logs build .#packages.${{ matrix.system }}.monad-bayes
       - name: Development environment
         run: nix --print-build-logs develop .#packages.${{ matrix.system }}.monad-bayes --command echo Ready
+      - name: All GHCs
+        run: nix --print-build-logs build .#packages.${{ matrix.system }}.monad-bayes-all-ghcs

--- a/flake.nix
+++ b/flake.nix
@@ -74,30 +74,6 @@
         monad-bayes = pkgs.haskell.packages.ghc902.developPackage {
           name = "monad-bayes";
           root = src;
-
-          # Remove this override when bumping nixpkgs
-          source-overrides = {
-            vty = pkgs.fetchzip {
-              url = "mirror://hackage/vty-5.37/vty-5.37.tar.gz";
-              sha256 = "sha256-OOrJBi/mSIyaibgObrp6NmUTWxRu9pxmjAL0EuPV9wY=";
-            };
-
-            text-zipper = pkgs.fetchzip {
-              url = "mirror://hackage/text-zipper-0.12/text-zipper-0.12.tar.gz";
-              sha256 = "sha256-P2/UHuG3UuSN7G31DyYvyUWSyIj2YXAOmjGkHtTaP8o=";
-            };
-
-            bimap = pkgs.fetchzip {
-              url = "mirror://hackage/bimap-0.5.0/bimap-0.5.0.tar.gz";
-              sha256 = "sha256-pbw+xg9Qz/c7YoXAJg8SR11RJGmgMw5hhnzKv+bGK9w=";
-            };
-
-            brick = pkgs.fetchzip {
-              url = "mirror://hackage/brick-1.4/brick-1.4.tar.gz";
-              sha256 = "sha256-KDa7RVQQPpinkJ0aKsYP0E50pn2auEIP38l6Uk7GmmE=";
-            };
-          };
-
           cabal2nixOptions = "--benchmark -fdev";
         };
 

--- a/monad-bayes.cabal
+++ b/monad-bayes.cabal
@@ -7,7 +7,7 @@ copyright:          2015-2020 Adam Scibior
 maintainer:         dominic.steinitz@tweag.io
 author:             Adam Scibior <adscib@gmail.com>
 stability:          experimental
-tested-with:        GHC ==9.2.2
+tested-with:        GHC ==9.0.2 || ==9.2.7
 homepage:           http://github.com/tweag/monad-bayes#readme
 bug-reports:        https://github.com/tweag/monad-bayes/issues
 synopsis:           A library for probabilistic programming.


### PR DESCRIPTION
This adds a list of GHC versions in `flake.nix` which can be extended. Each of these versions is used to build and test the package.