### PR TITLE
Fix cache

### DIFF
--- a/.github/actions/nix-common-setup/action.yml
+++ b/.github/actions/nix-common-setup/action.yml
@@ -10,7 +10,7 @@ runs:
     - name: Installing Nix
       uses: cachix/install-nix-action@v20
       with:
-        nix_path: nixpkgs=channel:nixpkgs-unstable
+        nix_path: nixpkgs=channel:nixos-unstable
 
     - uses: cachix/cachix-action@v12
       with:

--- a/.github/actions/nix-common-setup/action.yml
+++ b/.github/actions/nix-common-setup/action.yml
@@ -8,7 +8,7 @@ runs:
   steps:
 
     - name: Installing Nix
-      uses: cachix/install-nix-action@v16
+      uses: cachix/install-nix-action@v20
       with:
         nix_path: nixpkgs=channel:nixpkgs-unstable
 

--- a/.github/actions/nix-common-setup/action.yml
+++ b/.github/actions/nix-common-setup/action.yml
@@ -12,7 +12,7 @@ runs:
       with:
         nix_path: nixpkgs=channel:nixpkgs-unstable
 
-    #- uses: cachix/cachix-action@v10
-    #  with:
-    #    name: tweag-monad-bayes
-    #    authToken: "${{ inputs.CACHIX_AUTH_TOKEN }}"
+    - uses: cachix/cachix-action@v12
+      with:
+        name: tweag-monad-bayes
+        authToken: "${{ inputs.CACHIX_AUTH_TOKEN }}"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,3 +11,19 @@ updates:
     commit-message:
         prefix: "chore"
         include: "scope"
+
+# By default, when `package-ecosystem: github-actions` is set,
+# dependabot only looks in the `.github/workflows` directory,
+# even when setting `directory: "/"`.
+# But we need to keep updating the common nix setup as well.
+# Hopefully the following works.
+  - package-ecosystem: github-actions
+    directory: ".github/actions"
+    schedule:
+      interval: daily
+      time: '00:00'
+      timezone: UTC
+    open-pull-requests-limit: 10
+    commit-message:
+        prefix: "chore-actions"
+        include: "scope"

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -17,11 +17,10 @@ jobs:
         uses: cachix/install-nix-action@v20
         with:
           nix_path: nixpkgs=channel:nixos-unstable
-
       - uses: cachix/cachix-action@v12
         with:
           name: tweag-monad-bayes
-          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
       - name: Lint
         run: nix --print-build-logs build .#pre-commit --accept-flake-config
 

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: cachix/cachix-action@v12
         with:
           name: tweag-monad-bayes
-          authToken: "${{ inputs.CACHIX_AUTH_TOKEN }}"
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
       - name: Lint
         run: nix --print-build-logs build .#pre-commit
 

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -13,10 +13,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Setup Nix Environment
-        uses: ./.github/actions/nix-common-setup
-        # with:
-        #   CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
+      - name: Installing Nix
+        uses: cachix/install-nix-action@v20
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
+
+      - uses: cachix/cachix-action@v12
+        with:
+          name: tweag-monad-bayes
+          authToken: "${{ inputs.CACHIX_AUTH_TOKEN }}"
       - name: Lint
         run: nix --print-build-logs build .#pre-commit
 
@@ -34,8 +39,8 @@ jobs:
       - uses: actions/checkout@v3
       - name: Setup Nix Environment
         uses: ./.github/actions/nix-common-setup
-        # with:
-        #   CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
+        with:
+          CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
       - name: Build
         run: nix --print-build-logs build .#packages.${{ matrix.system }}.monad-bayes
       - name: Development environment

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -23,7 +23,7 @@ jobs:
           name: tweag-monad-bayes
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
       - name: Lint
-        run: nix --print-build-logs build .#pre-commit
+        run: nix --print-build-logs build .#pre-commit --accept-flake-config
 
 
   build:

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -15,8 +15,8 @@ jobs:
       - uses: actions/checkout@v3
       - name: Setup Nix Environment
         uses: ./.github/actions/nix-common-setup
-        with:
-          CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
+        # with:
+        #   CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
       - name: Lint
         run: nix --print-build-logs build .#pre-commit
 
@@ -34,8 +34,8 @@ jobs:
       - uses: actions/checkout@v3
       - name: Setup Nix Environment
         uses: ./.github/actions/nix-common-setup
-        with:
-          CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
+        # with:
+        #   CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
       - name: Build
         run: nix --print-build-logs build .#packages.${{ matrix.system }}.monad-bayes
       - name: Development environment

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Setup Nix Environenment
+      - name: Setup Nix Environment
         uses: ./.github/actions/nix-common-setup
         with:
           CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
@@ -32,7 +32,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
-      - name: Setup Nix Environenment
+      - name: Setup Nix Environment
         uses: ./.github/actions/nix-common-setup
         with:
           CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -25,6 +25,7 @@ jobs:
       - name: Lint
         run: nix --print-build-logs build .#pre-commit
 
+
   build:
     needs: lint
     strategy:


### PR DESCRIPTION
Also tries to run dependabot on common nix actions located in `.github/actions`. This was previously not the case because dependabot restricts itself to `.github/workflows` by default. Hopefully fixes #273 .