### PR TITLE
Use nixos-unstable instead of nixpkgs-unstable on CI

### DIFF
--- a/.github/actions/nix-common-setup/action.yml
+++ b/.github/actions/nix-common-setup/action.yml
@@ -10,7 +10,7 @@ runs:
     - name: Installing Nix
       uses: cachix/install-nix-action@v16
       with:
-        nix_path: nixpkgs=channel:nixpkgs-unstable
+        nix_path: nixpkgs=channel:nixos-unstable
 
     #- uses: cachix/cachix-action@v10
     #  with:


### PR DESCRIPTION
I'm hoping that this will speed up CI a lot. See https://github.com/tweag/monad-bayes/issues/273#issuecomment-1551098098.