### PR TITLE
Allow vector-0.13

### DIFF
--- a/monad-bayes.cabal
+++ b/monad-bayes.cabal
@@ -61,7 +61,7 @@ common deps
     , scientific       ^>=0.3
     , statistics       >=0.14.0  && <0.17
     , text             >=1.2     && <2.1
-    , vector           ^>=0.12.0
+    , vector           >=0.12.0  && <0.14
     , vty              ^>=5.38
 
 common test-deps


### PR DESCRIPTION
vector-0.13 is released, and it seems like `monad-bayes` works well with it. See https://github.com/NixOS/nixpkgs/pull/248112/files for a workaround that was necessary because of the restrictive upper bound.