### PR TITLE
Re-format with ormolu 0.5.3

### DIFF
--- a/benchmark/Speed.hs
+++ b/benchmark/Speed.hs
@@ -40,7 +40,7 @@ instance Show Model where
   show (HMM xs) = "HMM" ++ show (length xs)
   show (LDA xs) = "LDA" ++ show (length $ head xs)
 
-buildModel :: MonadMeasure m => Model -> m String
+buildModel :: (MonadMeasure m) => Model -> m String
 buildModel (LR dataset) = show <$> LogReg.logisticRegression dataset
 buildModel (HMM dataset) = show <$> HMM.hmm dataset
 buildModel (LDA dataset) = show <$> LDA.lda dataset

--- a/flake.nix
+++ b/flake.nix
@@ -81,10 +81,7 @@
             modifier = drv: if system == "x86_64-linux" then drv else pkgs.haskell.lib.dontCheck drv;
             overrides = self: super: with pkgs.haskell.lib; { # Please check after flake.lock updates whether some of these overrides can be removed
               string-qq = dontCheck super.string-qq;
-              hspec = super.hspec_2_11_1;
-              lens = super.lens_5_2_2;
-              linear = super.linear_1_22;
-              vty = super.vty_5_38;
+              hspec = super.hspec_2_11_4;
             };
           };
           ghcs = [ # Always keep this up to date with the tested-with section in monad-bayes.cabal!

--- a/models/BetaBin.hs
+++ b/models/BetaBin.hs
@@ -17,14 +17,14 @@ import Pipes ((<-<))
 import Pipes.Prelude qualified as P hiding (show)
 
 -- | Beta-binomial model as an i.i.d. sequence conditionally on weight.
-latent :: MonadDistribution m => Int -> m [Bool]
+latent :: (MonadDistribution m) => Int -> m [Bool]
 latent n = do
   weight <- uniform 0 1
   replicateM n (bernoulli weight)
 
 -- | Beta-binomial as a random process.
 -- Equivalent to the above by De Finetti's theorem.
-urn :: MonadDistribution m => Int -> m [Bool]
+urn :: (MonadDistribution m) => Int -> m [Bool]
 urn n = flip evalStateT (1, 1) $ do
   replicateM n do
     (a, b) <- get
@@ -36,7 +36,7 @@ urn n = flip evalStateT (1, 1) $ do
 
 -- | Beta-binomial as a random process.
 -- This time using the Pipes library, for a more pure functional style
-urnP :: MonadDistribution m => Int -> m [Bool]
+urnP :: (MonadDistribution m) => Int -> m [Bool]
 urnP n = P.toListM $ P.take n <-< P.unfoldr toss (1, 1)
   where
     toss (a, b) = do
@@ -47,7 +47,7 @@ urnP n = P.toListM $ P.take n <-< P.unfoldr toss (1, 1)
 
 -- | A beta-binomial model where the first three states are True,True,False.
 -- The resulting distribution is on the remaining outcomes.
-cond :: MonadMeasure m => m [Bool] -> m [Bool]
+cond :: (MonadMeasure m) => m [Bool] -> m [Bool]
 cond d = do
   ~(first : second : third : rest) <- d
   condition first
@@ -56,7 +56,7 @@ cond d = do
   return rest
 
 -- | The final conditional model, abstracting the representation.
-model :: MonadMeasure m => (Int -> m [Bool]) -> Int -> m Int
+model :: (MonadMeasure m) => (Int -> m [Bool]) -> Int -> m Int
 model repr n = fmap count $ cond $ repr (n + 3)
   where
     -- Post-processing by counting the number of True values.

--- a/models/ConjugatePriors.hs
+++ b/models/ConjugatePriors.hs
@@ -41,16 +41,16 @@ betaBernoulliAnalytic (a, b) points = beta a' b'
     a' = a + s
     b' = b + fromIntegral n - s
 
-bernoulliPdf :: Floating a => a -> Bool -> Log a
+bernoulliPdf :: (Floating a) => a -> Bool -> Log a
 bernoulliPdf p x = let numBool = if x then 1.0 else 0 in Exp $ log (p ** numBool * (1 - p) ** (1 - numBool))
 
-betaBernoulli' :: MonadMeasure m => (Double, Double) -> Bayesian m Double Bool
+betaBernoulli' :: (MonadMeasure m) => (Double, Double) -> Bayesian m Double Bool
 betaBernoulli' (a, b) = Bayesian (beta a b) bernoulli bernoulliPdf
 
-normalNormal' :: MonadMeasure m => Double -> (Double, Double) -> Bayesian m Double Double
+normalNormal' :: (MonadMeasure m) => Double -> (Double, Double) -> Bayesian m Double Double
 normalNormal' var (mu0, var0) = Bayesian (normal mu0 (sqrt var0)) (`normal` (sqrt var)) (`normalPdf` (sqrt var))
 
-gammaNormal' :: MonadMeasure m => (Double, Double) -> Bayesian m Double Double
+gammaNormal' :: (MonadMeasure m) => (Double, Double) -> Bayesian m Double Double
 gammaNormal' (a, b) = Bayesian (gamma a (recip b)) (normal 0 . sqrt . recip) (normalPdf 0 . sqrt . recip)
 
 normalNormalAnalytic ::

--- a/models/Dice.hs
+++ b/models/Dice.hs
@@ -12,23 +12,23 @@ import Control.Monad.Bayes.Class
   )
 
 -- | A toss of a six-sided die.
-die :: MonadDistribution m => m Int
+die :: (MonadDistribution m) => m Int
 die = uniformD [1 .. 6]
 
 -- | A sum of outcomes of n independent tosses of six-sided dice.
-dice :: MonadDistribution m => Int -> m Int
+dice :: (MonadDistribution m) => Int -> m Int
 dice 1 = die
 dice n = liftA2 (+) die (dice (n - 1))
 
 -- | Toss of two dice where the output is greater than 4.
-diceHard :: MonadMeasure m => m Int
+diceHard :: (MonadMeasure m) => m Int
 diceHard = do
   result <- dice 2
   condition (result > 4)
   return result
 
 -- | Toss of two dice with an artificial soft constraint.
-diceSoft :: MonadMeasure m => m Int
+diceSoft :: (MonadMeasure m) => m Int
 diceSoft = do
   result <- dice 2
   score (1 / fromIntegral result)

--- a/models/Helper.hs
+++ b/models/Helper.hs
@@ -39,7 +39,7 @@ serializeModel (LDA _) = Nothing
 data Alg = SMC | MH | RMSMC
   deriving stock (Read, Show, Eq, Ord, Enum, Bounded)
 
-getModel :: MonadMeasure m => Model -> (Int, m String)
+getModel :: (MonadMeasure m) => Model -> (Int, m String)
 getModel model = (size model, program model)
   where
     size (LR n) = n

--- a/models/LDA.hs
+++ b/models/LDA.hs
@@ -43,17 +43,17 @@ documents =
     words "bear wolf bear python bear wolf bear wolf bear wolf"
   ]
 
-wordDistPrior :: MonadDistribution m => m (V.Vector Double)
+wordDistPrior :: (MonadDistribution m) => m (V.Vector Double)
 wordDistPrior = dirichlet $ V.replicate (length vocabulary) 1
 
-topicDistPrior :: MonadDistribution m => m (V.Vector Double)
+topicDistPrior :: (MonadDistribution m) => m (V.Vector Double)
 topicDistPrior = dirichlet $ V.replicate (length topics) 1
 
 wordIndex :: Map.Map Text Int
 wordIndex = Map.fromList $ zip vocabulary [0 ..]
 
 lda ::
-  MonadMeasure m =>
+  (MonadMeasure m) =>
   Documents ->
   m (Map.Map Text (V.Vector (Text, Double)), [(Text, V.Vector (Text, Double))])
 lda docs = do
@@ -73,7 +73,7 @@ lda docs = do
       zip (fmap (foldr1 (\x y -> x <> " " <> y)) docs) (fmap (V.zip $ V.fromList ["topic1", "topic2"]) td)
     )
 
-syntheticData :: MonadDistribution m => Int -> Int -> m [[Text]]
+syntheticData :: (MonadDistribution m) => Int -> Int -> m [[Text]]
 syntheticData d w = List.replicateM d (List.replicateM w syntheticWord)
   where
     syntheticWord = uniformD vocabulary

--- a/models/LogReg.hs
+++ b/models/LogReg.hs
@@ -13,7 +13,7 @@ import Control.Monad.Bayes.Class
   )
 import Numeric.Log (Log (Exp))
 
-logisticRegression :: MonadMeasure m => [(Double, Bool)] -> m Double
+logisticRegression :: (MonadMeasure m) => [(Double, Bool)] -> m Double
 logisticRegression dat = do
   m <- normal 0 1
   b <- normal 0 1
@@ -27,7 +27,7 @@ logisticRegression dat = do
   sigmoid 8
 
 -- make a synthetic dataset by randomly choosing input-label pairs
-syntheticData :: MonadDistribution m => Int -> m [(Double, Bool)]
+syntheticData :: (MonadDistribution m) => Int -> m [(Double, Bool)]
 syntheticData n = replicateM n do
   x <- uniform (-1) 1
   label <- bernoulli 0.5

--- a/models/NestedInference.hs
+++ b/models/NestedInference.hs
@@ -13,14 +13,14 @@ data State = Square | Circle deriving (Eq, Show, Ord)
 data Action = Speak Utterance | DoNothing deriving (Eq, Show, Ord)
 
 -- | uniformly likely to say any true utterance to convey the given state
-truthfulAgent :: MonadDistribution m => State -> m Action
+truthfulAgent :: (MonadDistribution m) => State -> m Action
 truthfulAgent state = uniformD case state of
   Square -> [Speak ASquare, Speak AShape, DoNothing]
   Circle -> [Speak AShape, DoNothing]
 
 -- | a listener which applies Bayes rule to infer the state
 -- given an observed action of the other agent
-listener :: MonadMeasure m => Action -> m State
+listener :: (MonadMeasure m) => Action -> m State
 listener observedAction = do
   state <- uniformD [Square, Circle]
   factor $ log $ Exp $ mass (truthfulAgent state) observedAction
@@ -28,7 +28,7 @@ listener observedAction = do
 
 -- | an agent which produces an action by reasoning about
 -- how the listener would interpret it
-informativeAgent :: MonadMeasure m => State -> m Action
+informativeAgent :: (MonadMeasure m) => State -> m Action
 informativeAgent state = do
   utterance <- uniformD [Speak ASquare, Speak AShape, DoNothing]
   factor $ log $ Exp $ mass (listener utterance) state

--- a/models/NonlinearSSM.hs
+++ b/models/NonlinearSSM.hs
@@ -7,7 +7,7 @@ import Control.Monad.Bayes.Class
     normalPdf,
   )
 
-param :: MonadDistribution m => m (Double, Double)
+param :: (MonadDistribution m) => m (Double, Double)
 param = do
   let a = 0.01
   let b = 0.01
@@ -43,7 +43,7 @@ model obs (sigmaX, sigmaY) = do
   return $ reverse xs
 
 generateData ::
-  MonadDistribution m =>
+  (MonadDistribution m) =>
   -- | T
   Int ->
   -- | list of latent and observable states from t=1

--- a/models/NonlinearSSM/Algorithms.hs
+++ b/models/NonlinearSSM/Algorithms.hs
@@ -22,7 +22,7 @@ t :: Int
 t = 5
 
 -- FIXME refactor such that it can be reused in ssm benchmark
-runAlgFixed :: MonadDistribution m => SSMData -> Alg -> m String
+runAlgFixed :: (MonadDistribution m) => SSMData -> Alg -> m String
 runAlgFixed ys SMC = fmap show $ population $ smc SMCConfig {numSteps = t, numParticles = 10, resampler = resampleMultinomial} (param >>= model ys)
 runAlgFixed ys RMSMC =
   fmap show $

--- a/models/Sprinkler.hs
+++ b/models/Sprinkler.hs
@@ -3,7 +3,7 @@ module Sprinkler (hard, soft) where
 import Control.Monad (when)
 import Control.Monad.Bayes.Class
 
-hard :: MonadMeasure m => m Bool
+hard :: (MonadMeasure m) => m Bool
 hard = do
   rain <- bernoulli 0.3
   sprinkler <- bernoulli $ if rain then 0.1 else 0.4
@@ -15,7 +15,7 @@ hard = do
   condition (not wet)
   return rain
 
-soft :: MonadMeasure m => m Bool
+soft :: (MonadMeasure m) => m Bool
 soft = do
   rain <- bernoulli 0.3
   when rain (factor 0.2)

--- a/models/StrictlySmallerSupport.hs
+++ b/models/StrictlySmallerSupport.hs
@@ -5,7 +5,7 @@ module StrictlySmallerSupport (model) where
 
 import Control.Monad.Bayes.Class
 
-model :: MonadDistribution m => m Bool
+model :: (MonadDistribution m) => m Bool
 model = do
   x <- bernoulli 0.5
   _ <- uniformD (if x then [1, 2] else [1, 2, 3, 4] :: [Int])

--- a/src/Control/Monad/Bayes/Density/State.hs
+++ b/src/Control/Monad/Bayes/Density/State.hs
@@ -18,16 +18,16 @@ newtype Density m a = Density {runDensity :: WriterT [Double] (StateT [Double] m
 instance MonadTrans Density where
   lift = Density . lift . lift
 
-instance Monad m => MonadState [Double] (Density m) where
+instance (Monad m) => MonadState [Double] (Density m) where
   get = Density $ lift $ get
   put = Density . lift . put
 
-instance Monad m => MonadWriter [Double] (Density m) where
+instance (Monad m) => MonadWriter [Double] (Density m) where
   tell = Density . tell
   listen = Density . listen . runDensity
   pass = Density . pass . runDensity
 
-instance MonadDistribution m => MonadDistribution (Density m) where
+instance (MonadDistribution m) => MonadDistribution (Density m) where
   random = do
     trace <- get
     x <- case trace of
@@ -36,5 +36,5 @@ instance MonadDistribution m => MonadDistribution (Density m) where
     tell [x]
     pure x
 
-density :: Monad m => Density m b -> [Double] -> m (b, [Double])
+density :: (Monad m) => Density m b -> [Double] -> m (b, [Double])
 density (Density m) = evalStateT (runWriterT m)

--- a/src/Control/Monad/Bayes/Enumerator.hs
+++ b/src/Control/Monad/Bayes/Enumerator.hs
@@ -80,7 +80,7 @@ evidence :: Enumerator a -> Log Double
 evidence = Log.sum . map snd . logExplicit
 
 -- | Normalized probability mass of a specific value.
-mass :: Ord a => Enumerator a -> a -> Double
+mass :: (Ord a) => Enumerator a -> a -> Double
 mass d = f
   where
     f a = fromMaybe 0 $ lookup a m
@@ -95,7 +95,7 @@ compact = sortOn (Down . snd) . Map.toAscList . Map.fromListWith (+)
 -- The resulting list is sorted ascendingly according to values.
 --
 -- > enumerator = compact . explicit
-enumerator, enumerate :: Ord a => Enumerator a -> [(a, Double)]
+enumerator, enumerate :: (Ord a) => Enumerator a -> [(a, Double)]
 enumerator d = filter ((/= 0) . snd) $ compact (zip xs ws)
   where
     (xs, ws) = second (map (exp . ln) . normalize) $ unzip (logExplicit d)
@@ -107,20 +107,20 @@ enumerate = enumerator
 expectation :: (a -> Double) -> Enumerator a -> Double
 expectation f = Prelude.sum . map (\(x, w) -> f x * (exp . ln) w) . normalizeWeights . logExplicit
 
-normalize :: Fractional b => [b] -> [b]
+normalize :: (Fractional b) => [b] -> [b]
 normalize xs = map (/ z) xs
   where
     z = Prelude.sum xs
 
 -- | Divide all weights by their sum.
-normalizeWeights :: Fractional b => [(a, b)] -> [(a, b)]
+normalizeWeights :: (Fractional b) => [(a, b)] -> [(a, b)]
 normalizeWeights ls = zip xs ps
   where
     (xs, ws) = unzip ls
     ps = normalize ws
 
 -- | 'compact' followed by removing values with zero weight.
-normalForm :: Ord a => Enumerator a -> [(a, Double)]
+normalForm :: (Ord a) => Enumerator a -> [(a, Double)]
 normalForm = filter ((/= 0) . snd) . compact . explicit
 
 toEmpirical :: (Fractional b, Ord a, Ord b) => [a] -> [(a, b)]
@@ -139,10 +139,10 @@ enumerateToDistribution model = do
 removeZeros :: Enumerator a -> Enumerator a
 removeZeros (Enumerator (WriterT a)) = Enumerator $ WriterT $ filter ((\(Product x) -> x /= 0) . snd) a
 
-instance Ord a => Eq (Enumerator a) where
+instance (Ord a) => Eq (Enumerator a) where
   p == q = normalForm p == normalForm q
 
-instance Ord a => AEq (Enumerator a) where
+instance (Ord a) => AEq (Enumerator a) where
   p === q = xs == ys && ps === qs
     where
       (xs, ps) = unzip (normalForm p)

--- a/src/Control/Monad/Bayes/Inference/Lazy/MH.hs
+++ b/src/Control/Monad/Bayes/Inference/Lazy/MH.hs
@@ -61,7 +61,7 @@ mh p m = do
         else return (t, x, w)
 
 -- Replace the labels of a tree randomly, with probability p
-mutateTree :: forall g. RandomGen g => Double -> g -> Tree -> Tree
+mutateTree :: forall g. (RandomGen g) => Double -> g -> Tree -> Tree
 mutateTree p g (Tree a ts) =
   let (a', g') = (R.random g :: (Double, g))
       (a'', g'') = R.random g'
@@ -70,7 +70,7 @@ mutateTree p g (Tree a ts) =
           lazyUniforms = mutateTrees p g'' ts
         }
 
-mutateTrees :: RandomGen g => Double -> g -> Trees -> Trees
+mutateTrees :: (RandomGen g) => Double -> g -> Trees -> Trees
 mutateTrees p g (Trees t ts) =
   let (g1, g2) = split g
    in Trees

--- a/src/Control/Monad/Bayes/Inference/Lazy/WIS.hs
+++ b/src/Control/Monad/Bayes/Inference/Lazy/WIS.hs
@@ -18,6 +18,6 @@ lwis n m = do
   rs <- randoms <$> getStdGen
   return $ fmap (\r -> fst $ head $ filter ((>= Exp (log r) * max') . snd) xws') rs
   where
-    accumulate :: Num t => [(a, t)] -> t -> [(a, t)]
+    accumulate :: (Num t) => [(a, t)] -> t -> [(a, t)]
     accumulate ((x, w) : xws) a = (x, w + a) : (x, w + a) : accumulate xws (w + a)
     accumulate [] _ = []

--- a/src/Control/Monad/Bayes/Inference/MCMC.hs
+++ b/src/Control/Monad/Bayes/Inference/MCMC.hs
@@ -33,24 +33,24 @@ data MCMCConfig = MCMCConfig {proposal :: Proposal, numMCMCSteps :: Int, numBurn
 defaultMCMCConfig :: MCMCConfig
 defaultMCMCConfig = MCMCConfig {proposal = SingleSiteMH, numMCMCSteps = 1, numBurnIn = 0}
 
-mcmc :: MonadDistribution m => MCMCConfig -> Static.Traced (Weighted m) a -> m [a]
+mcmc :: (MonadDistribution m) => MCMCConfig -> Static.Traced (Weighted m) a -> m [a]
 mcmc (MCMCConfig {..}) m = burnIn numBurnIn $ unweighted $ Static.mh numMCMCSteps m
 
-mcmcBasic :: MonadDistribution m => MCMCConfig -> Basic.Traced (Weighted m) a -> m [a]
+mcmcBasic :: (MonadDistribution m) => MCMCConfig -> Basic.Traced (Weighted m) a -> m [a]
 mcmcBasic (MCMCConfig {..}) m = burnIn numBurnIn $ unweighted $ Basic.mh numMCMCSteps m
 
-mcmcDynamic :: MonadDistribution m => MCMCConfig -> Dynamic.Traced (Weighted m) a -> m [a]
+mcmcDynamic :: (MonadDistribution m) => MCMCConfig -> Dynamic.Traced (Weighted m) a -> m [a]
 mcmcDynamic (MCMCConfig {..}) m = burnIn numBurnIn $ unweighted $ Dynamic.mh numMCMCSteps m
 
 -- -- | draw iid samples until you get one that has non-zero likelihood
-independentSamples :: Monad m => Static.Traced m a -> P.Producer (MHResult a) m (Trace a)
+independentSamples :: (Monad m) => Static.Traced m a -> P.Producer (MHResult a) m (Trace a)
 independentSamples (Static.Traced _w d) =
   P.repeatM d
     >-> P.takeWhile' ((== 0) . probDensity)
     >-> P.map (MHResult False)
 
 -- | convert a probabilistic program into a producer of samples
-mcmcP :: MonadDistribution m => MCMCConfig -> Static.Traced m a -> P.Producer (MHResult a) m ()
+mcmcP :: (MonadDistribution m) => MCMCConfig -> Static.Traced m a -> P.Producer (MHResult a) m ()
 mcmcP MCMCConfig {..} m@(Static.Traced w _) = do
   initialValue <- independentSamples m >-> P.drain
   ( P.unfoldr (fmap (Right . (\k -> (k, trace k))) . mhTransWithBool w) initialValue

--- a/src/Control/Monad/Bayes/Inference/PMMH.hs
+++ b/src/Control/Monad/Bayes/Inference/PMMH.hs
@@ -35,7 +35,7 @@ import Numeric.Log (Log)
 
 -- | Particle Marginal Metropolis-Hastings sampling.
 pmmh ::
-  MonadDistribution m =>
+  (MonadDistribution m) =>
   MCMCConfig ->
   SMCConfig (Weighted m) ->
   Traced (Weighted m) a1 ->
@@ -54,9 +54,9 @@ pmmh mcmcConf smcConf param model =
 
 -- | Particle Marginal Metropolis-Hastings sampling from a Bayesian model
 pmmhBayesianModel ::
-  MonadMeasure m =>
+  (MonadMeasure m) =>
   MCMCConfig ->
   SMCConfig (Weighted m) ->
-  (forall m'. MonadMeasure m' => Bayesian m' a1 a2) ->
+  (forall m'. (MonadMeasure m') => Bayesian m' a1 a2) ->
   m [[(a2, Log Double)]]
 pmmhBayesianModel mcmcConf smcConf bm = pmmh mcmcConf smcConf (prior bm) (generative bm)

--- a/src/Control/Monad/Bayes/Inference/RMSMC.hs
+++ b/src/Control/Monad/Bayes/Inference/RMSMC.hs
@@ -42,7 +42,7 @@ import Data.Monoid (Endo (..))
 
 -- | Resample-move Sequential Monte Carlo.
 rmsmc ::
-  MonadDistribution m =>
+  (MonadDistribution m) =>
   MCMCConfig ->
   SMCConfig m ->
   -- | model
@@ -56,7 +56,7 @@ rmsmc (MCMCConfig {..}) (SMCConfig {..}) =
 -- | Resample-move Sequential Monte Carlo with a more efficient
 -- tracing representation.
 rmsmcBasic ::
-  MonadDistribution m =>
+  (MonadDistribution m) =>
   MCMCConfig ->
   SMCConfig m ->
   -- | model
@@ -71,7 +71,7 @@ rmsmcBasic (MCMCConfig {..}) (SMCConfig {..}) =
 -- where only random variables since last resampling are considered
 -- for rejuvenation.
 rmsmcDynamic ::
-  MonadDistribution m =>
+  (MonadDistribution m) =>
   MCMCConfig ->
   SMCConfig m ->
   -- | model

--- a/src/Control/Monad/Bayes/Inference/SMC.hs
+++ b/src/Control/Monad/Bayes/Inference/SMC.hs
@@ -37,7 +37,7 @@ data SMCConfig m = SMCConfig
 -- | Sequential importance resampling.
 -- Basically an SMC template that takes a custom resampler.
 smc ::
-  MonadDistribution m =>
+  (MonadDistribution m) =>
   SMCConfig m ->
   Coroutine.Sequential (Population m) a ->
   Population m a
@@ -49,5 +49,5 @@ smc SMCConfig {..} =
 -- Weights are normalized at each timestep and the total weight is pushed
 -- as a score into the transformed monad.
 smcPush ::
-  MonadMeasure m => SMCConfig m -> Coroutine.Sequential (Population m) a -> Population m a
+  (MonadMeasure m) => SMCConfig m -> Coroutine.Sequential (Population m) a -> Population m a
 smcPush config = smc config {resampler = (pushEvidence . resampler config)}

--- a/src/Control/Monad/Bayes/Inference/SMC2.hs
+++ b/src/Control/Monad/Bayes/Inference/SMC2.hs
@@ -43,17 +43,17 @@ setup (SMC2 m) = m
 instance MonadTrans SMC2 where
   lift = SMC2 . lift . lift . lift
 
-instance MonadDistribution m => MonadDistribution (SMC2 m) where
+instance (MonadDistribution m) => MonadDistribution (SMC2 m) where
   random = lift random
 
-instance Monad m => MonadFactor (SMC2 m) where
+instance (Monad m) => MonadFactor (SMC2 m) where
   score = SMC2 . score
 
-instance MonadDistribution m => MonadMeasure (SMC2 m)
+instance (MonadDistribution m) => MonadMeasure (SMC2 m)
 
 -- | Sequential Monte Carlo squared.
 smc2 ::
-  MonadDistribution m =>
+  (MonadDistribution m) =>
   -- | number of time steps
   Int ->
   -- | number of inner particles

--- a/src/Control/Monad/Bayes/Inference/TUI.hs
+++ b/src/Control/Monad/Bayes/Inference/TUI.hs
@@ -106,7 +106,7 @@ showEmpirical =
     . (fmap (second (formatScientific Exponent (Just 3) . fromFloatDigits)))
     . toEmpirical
 
-showVal :: Show a => [a] -> Widget n
+showVal :: (Show a) => [a] -> Widget n
 showVal = txt . T.pack . (\case [] -> ""; a -> show $ head a)
 
 -- | handler for events received by the TUI
@@ -130,7 +130,7 @@ theMap =
       (attrName "highlight", fg yellow)
     ]
 
-tui :: Show a => Int -> Traced (Weighted SamplerIO) a -> ([a] -> Widget ()) -> IO ()
+tui :: (Show a) => Int -> Traced (Weighted SamplerIO) a -> ([a] -> Widget ()) -> IO ()
 tui burnIn distribution visualizer = void do
   eventChan <- B.newBChan 10
   initialVty <- buildVty

--- a/src/Control/Monad/Bayes/Integrator.hs
+++ b/src/Control/Monad/Bayes/Integrator.hs
@@ -68,20 +68,20 @@ fromDensityFunction d = Integrator $
   where
     integralWithQuadrature = result . last . (\z -> trap z 0 1)
 
-fromMassFunction :: Foldable f => (a -> Double) -> f a -> Integrator a
+fromMassFunction :: (Foldable f) => (a -> Double) -> f a -> Integrator a
 fromMassFunction f support = Integrator $ cont \g ->
   foldl' (\acc x -> acc + f x * g x) 0 support
 
-empirical :: Foldable f => f a -> Integrator a
+empirical :: (Foldable f) => f a -> Integrator a
 empirical = Integrator . cont . flip weightedAverage
   where
     weightedAverage :: (Foldable f, Fractional r) => (a -> r) -> f a -> r
     weightedAverage f = Foldl.fold (weightedAverageFold f)
 
-    weightedAverageFold :: Fractional r => (a -> r) -> Fold a r
+    weightedAverageFold :: (Fractional r) => (a -> r) -> Fold a r
     weightedAverageFold f = Foldl.premap f averageFold
 
-    averageFold :: Fractional a => Fold a a
+    averageFold :: (Fractional a) => Fold a a
     averageFold = (/) <$> Foldl.sum <*> Foldl.genericLength
 
 expectation :: Integrator Double -> Double
@@ -124,7 +124,7 @@ containing xs x
   | x `elem` xs = 1
   | otherwise = 0
 
-instance Num a => Num (Integrator a) where
+instance (Num a) => Num (Integrator a) where
   (+) = liftA2 (+)
   (-) = liftA2 (-)
   (*) = liftA2 (*)
@@ -132,10 +132,10 @@ instance Num a => Num (Integrator a) where
   signum = fmap signum
   fromInteger = pure . fromInteger
 
-probability :: Ord a => (a, a) -> Integrator a -> Double
+probability :: (Ord a) => (a, a) -> Integrator a -> Double
 probability (lower, upper) = integrator (\x -> if x < upper && x >= lower then 1 else 0)
 
-enumeratorWith :: Ord a => Set a -> Integrator a -> [(a, Double)]
+enumeratorWith :: (Ord a) => Set a -> Integrator a -> [(a, Double)]
 enumeratorWith ls meas =
   [ ( val,
       integrator

--- a/src/Control/Monad/Bayes/Population.hs
+++ b/src/Control/Monad/Bayes/Population.hs
@@ -79,25 +79,25 @@ population (Population m) = runListT $ weighted m
 runPopulation = population
 
 -- | Explicit representation of the weighted sample.
-explicitPopulation :: Functor m => Population m a -> m [(a, Double)]
+explicitPopulation :: (Functor m) => Population m a -> m [(a, Double)]
 explicitPopulation = fmap (map (second (exp . ln))) . population
 
 -- | Initialize 'Population' with a concrete weighted sample.
-fromWeightedList :: Monad m => m [(a, Log Double)] -> Population m a
+fromWeightedList :: (Monad m) => m [(a, Log Double)] -> Population m a
 fromWeightedList = Population . withWeight . ListT
 
 -- | Increase the sample size by a given factor.
 -- The weights are adjusted such that their sum is preserved.
 -- It is therefore safe to use 'spawn' in arbitrary places in the program
 -- without introducing bias.
-spawn :: Monad m => Int -> Population m ()
+spawn :: (Monad m) => Int -> Population m ()
 spawn n = fromWeightedList $ pure $ replicate n ((), 1 / fromIntegral n)
 
-withParticles :: Monad m => Int -> Population m a -> Population m a
+withParticles :: (Monad m) => Int -> Population m a -> Population m a
 withParticles n = (spawn n >>)
 
 resampleGeneric ::
-  MonadDistribution m =>
+  (MonadDistribution m) =>
   -- | resampler
   (V.Vector Double -> m [Int]) ->
   Population m a ->
@@ -171,7 +171,7 @@ resampleSystematic = resampleGeneric (\ps -> (`systematic` ps) <$> random)
 -- and \(w^{(k)}\) are the weights.
 --
 -- The conditional variance of stratified sampling is always smaller than that of multinomial sampling and it is also unbiased - see  [Comparison of Resampling Schemes for Particle Filtering](https://arxiv.org/abs/cs/0507025).
-stratified :: MonadDistribution m => V.Vector Double -> m [Int]
+stratified :: (MonadDistribution m) => V.Vector Double -> m [Int]
 stratified weights = do
   let bigN = V.length weights
   dithers <- V.replicateM bigN (uniform 0.0 1.0)
@@ -199,7 +199,7 @@ resampleStratified = resampleGeneric stratified
 -- | Multinomial sampler.  Sample from \(0, \ldots, n - 1\) \(n\)
 -- times drawn at random according to the weights where \(n\) is the
 -- length of vector of weights.
-multinomial :: MonadDistribution m => V.Vector Double -> m [Int]
+multinomial :: (MonadDistribution m) => V.Vector Double -> m [Int]
 multinomial ps = replicateM (V.length ps) (categorical ps)
 
 -- | Resample the population using the underlying monad and a multinomial resampling scheme.
@@ -213,7 +213,7 @@ resampleMultinomial = resampleGeneric multinomial
 -- | Separate the sum of weights into the 'Weighted' transformer.
 -- Weights are normalized after this operation.
 extractEvidence ::
-  Monad m =>
+  (Monad m) =>
   Population m a ->
   Population (Weighted m) a
 extractEvidence m = fromWeightedList $ do
@@ -227,7 +227,7 @@ extractEvidence m = fromWeightedList $ do
 -- | Push the evidence estimator as a score to the transformed monad.
 -- Weights are normalized after this operation.
 pushEvidence ::
-  MonadFactor m =>
+  (MonadFactor m) =>
   Population m a ->
   Population m a
 pushEvidence = hoist applyWeight . extractEvidence
@@ -269,7 +269,7 @@ popAvg f p = do
 
 -- | Applies a transformation to the inner monad.
 hoist ::
-  Monad n =>
+  (Monad n) =>
   (forall x. m x -> n x) ->
   Population m a ->
   Population n a

--- a/src/Control/Monad/Bayes/Sampler/Lazy.hs
+++ b/src/Control/Monad/Bayes/Sampler/Lazy.hs
@@ -45,10 +45,10 @@ splitTree :: Tree -> (Tree, Tree)
 splitTree (Tree r (Trees t ts)) = (t, Tree r ts)
 
 -- | Preliminaries for the simulation methods. Generate a tree with uniform random labels. This uses 'split' to split a random seed
-randomTree :: RandomGen g => g -> Tree
+randomTree :: (RandomGen g) => g -> Tree
 randomTree g = let (a, g') = R.random g in Tree a (randomTrees g')
 
-randomTrees :: RandomGen g => g -> Trees
+randomTrees :: (RandomGen g) => g -> Trees
 randomTrees g = let (g1, g2) = split g in Trees (randomTree g1) (randomTrees g2)
 
 instance Applicative Sampler where
@@ -71,7 +71,7 @@ instance MonadDistribution Sampler where
 sampler :: Sampler a -> IO a
 sampler m = newStdGen *> (runSampler m . randomTree <$> getStdGen)
 
-independent :: Monad m => m a -> m [a]
+independent :: (Monad m) => m a -> m [a]
 independent = sequence . repeat
 
 -- | 'weightedsamples' runs a probability measure and gets out a stream of (result,weight) pairs

--- a/src/Control/Monad/Bayes/Sampler/Strict.hs
+++ b/src/Control/Monad/Bayes/Sampler/Strict.hs
@@ -58,7 +58,7 @@ type SamplerIO = Sampler (IOGenM StdGen) IO
 -- to particular pairs of monad and RNG
 type SamplerST s = Sampler (STGenM StdGen s) (ST s)
 
-instance StatefulGen g m => MonadDistribution (Sampler g m) where
+instance (StatefulGen g m) => MonadDistribution (Sampler g m) where
   random = Sampler (ReaderT uniformDouble01M)
 
   uniform a b = Sampler (ReaderT $ uniformRM (a, b))

--- a/src/Control/Monad/Bayes/Sequential/Coroutine.hs
+++ b/src/Control/Monad/Bayes/Sequential/Coroutine.hs
@@ -54,34 +54,34 @@ newtype Sequential m a = Sequential {runSequential :: Coroutine (Await ()) m a}
 extract :: Await () a -> a
 extract (Await f) = f ()
 
-instance MonadDistribution m => MonadDistribution (Sequential m) where
+instance (MonadDistribution m) => MonadDistribution (Sequential m) where
   random = lift random
   bernoulli = lift . bernoulli
   categorical = lift . categorical
 
 -- | Execution is 'suspend'ed after each 'score'.
-instance MonadFactor m => MonadFactor (Sequential m) where
+instance (MonadFactor m) => MonadFactor (Sequential m) where
   score w = lift (score w) >> suspend
 
-instance MonadMeasure m => MonadMeasure (Sequential m)
+instance (MonadMeasure m) => MonadMeasure (Sequential m)
 
 -- | A point where the computation is paused.
-suspend :: Monad m => Sequential m ()
+suspend :: (Monad m) => Sequential m ()
 suspend = Sequential await
 
 -- | Remove the remaining suspension points.
-finish :: Monad m => Sequential m a -> m a
+finish :: (Monad m) => Sequential m a -> m a
 finish = pogoStick extract . runSequential
 
 -- | Execute to the next suspension point.
 -- If the computation is finished, do nothing.
 --
 -- > finish = finish . advance
-advance :: Monad m => Sequential m a -> Sequential m a
+advance :: (Monad m) => Sequential m a -> Sequential m a
 advance = Sequential . bounce extract . runSequential
 
 -- | Return True if no more suspension points remain.
-finished :: Monad m => Sequential m a -> m Bool
+finished :: (Monad m) => Sequential m a -> m Bool
 finished = fmap isRight . resume . runSequential
 
 -- | Transform the inner monad.
@@ -106,7 +106,7 @@ composeCopies k f = foldr (.) id (replicate k f)
 -- Applies a given transformation after each time step.
 sequentially,
   sis ::
-    Monad m =>
+    (Monad m) =>
     -- | transformation
     (forall x. m x -> m x) ->
     -- | number of time steps

--- a/src/Control/Monad/Bayes/Traced/Basic.hs
+++ b/src/Control/Monad/Bayes/Traced/Basic.hs
@@ -43,43 +43,43 @@ data Traced m a = Traced
     traceDist :: m (Trace a)
   }
 
-instance Monad m => Functor (Traced m) where
+instance (Monad m) => Functor (Traced m) where
   fmap f (Traced m d) = Traced (fmap f m) (fmap (fmap f) d)
 
-instance Monad m => Applicative (Traced m) where
+instance (Monad m) => Applicative (Traced m) where
   pure x = Traced (pure x) (pure (pure x))
   (Traced mf df) <*> (Traced mx dx) = Traced (mf <*> mx) (liftA2 (<*>) df dx)
 
-instance Monad m => Monad (Traced m) where
+instance (Monad m) => Monad (Traced m) where
   (Traced mx dx) >>= f = Traced my dy
     where
       my = mx >>= model . f
       dy = dx `bind` (traceDist . f)
 
-instance MonadDistribution m => MonadDistribution (Traced m) where
+instance (MonadDistribution m) => MonadDistribution (Traced m) where
   random = Traced random (fmap singleton random)
 
-instance MonadFactor m => MonadFactor (Traced m) where
+instance (MonadFactor m) => MonadFactor (Traced m) where
   score w = Traced (score w) (score w >> pure (scored w))
 
-instance MonadMeasure m => MonadMeasure (Traced m)
+instance (MonadMeasure m) => MonadMeasure (Traced m)
 
 hoist :: (forall x. m x -> m x) -> Traced m a -> Traced m a
 hoist f (Traced m d) = Traced m (f d)
 
 -- | Discard the trace and supporting infrastructure.
-marginal :: Monad m => Traced m a -> m a
+marginal :: (Monad m) => Traced m a -> m a
 marginal (Traced _ d) = fmap output d
 
 -- | A single step of the Trace Metropolis-Hastings algorithm.
-mhStep :: MonadDistribution m => Traced m a -> Traced m a
+mhStep :: (MonadDistribution m) => Traced m a -> Traced m a
 mhStep (Traced m d) = Traced m d'
   where
     d' = d >>= mhTrans' m
 
 -- | Full run of the Trace Metropolis-Hastings algorithm with a specified
 -- number of steps.
-mh :: MonadDistribution m => Int -> Traced m a -> m [a]
+mh :: (MonadDistribution m) => Int -> Traced m a -> m [a]
 mh n (Traced m d) = fmap (map output . NE.toList) (f n)
   where
     f k

--- a/src/Control/Monad/Bayes/Traced/Common.hs
+++ b/src/Control/Monad/Bayes/Traced/Common.hs
@@ -74,14 +74,14 @@ singleton u = Trace {variables = [u], output = u, probDensity = 1}
 scored :: Log Double -> Trace ()
 scored w = Trace {variables = [], output = (), probDensity = w}
 
-bind :: Monad m => m (Trace a) -> (a -> m (Trace b)) -> m (Trace b)
+bind :: (Monad m) => m (Trace a) -> (a -> m (Trace b)) -> m (Trace b)
 bind dx f = do
   t1 <- dx
   t2 <- f (output t1)
   return $ t2 {variables = variables t1 ++ variables t2, probDensity = probDensity t1 * probDensity t2}
 
 -- | A single Metropolis-corrected transition of single-site Trace MCMC.
-mhTrans :: MonadDistribution m => (Weighted (State.Density m)) a -> Trace a -> m (Trace a)
+mhTrans :: (MonadDistribution m) => (Weighted (State.Density m)) a -> Trace a -> m (Trace a)
 mhTrans m t@Trace {variables = us, probDensity = p} = do
   let n = length us
   us' <- do
@@ -95,11 +95,11 @@ mhTrans m t@Trace {variables = us, probDensity = p} = do
   accept <- bernoulli ratio
   return $ if accept then Trace vs b q else t
 
-mhTransFree :: MonadDistribution m => Weighted (Free.Density m) a -> Trace a -> m (Trace a)
+mhTransFree :: (MonadDistribution m) => Weighted (Free.Density m) a -> Trace a -> m (Trace a)
 mhTransFree m t = trace <$> mhTransWithBool m t
 
 -- | A single Metropolis-corrected transition of single-site Trace MCMC.
-mhTransWithBool :: MonadDistribution m => Weighted (Free.Density m) a -> Trace a -> m (MHResult a)
+mhTransWithBool :: (MonadDistribution m) => Weighted (Free.Density m) a -> Trace a -> m (MHResult a)
 mhTransWithBool m t@Trace {variables = us, probDensity = p} = do
   let n = length us
   us' <- do
@@ -114,11 +114,11 @@ mhTransWithBool m t@Trace {variables = us, probDensity = p} = do
   return if accept then MHResult True (Trace vs b q) else MHResult False t
 
 -- | A variant of 'mhTrans' with an external sampling monad.
-mhTrans' :: MonadDistribution m => Weighted (Free.Density Identity) a -> Trace a -> m (Trace a)
+mhTrans' :: (MonadDistribution m) => Weighted (Free.Density Identity) a -> Trace a -> m (Trace a)
 mhTrans' m = mhTransFree (Weighted.hoist (Free.hoist (return . runIdentity)) m)
 
 -- | burn in an MCMC chain for n steps (which amounts to dropping samples of the end of the list)
-burnIn :: Functor m => Int -> m [a] -> m [a]
+burnIn :: (Functor m) => Int -> m [a] -> m [a]
 burnIn n = fmap dropEnd
   where
     dropEnd ls = let len = length ls in take (len - n) ls

--- a/src/Control/Monad/Bayes/Traced/Static.hs
+++ b/src/Control/Monad/Bayes/Traced/Static.hs
@@ -45,14 +45,14 @@ data Traced m a = Traced
     traceDist :: m (Trace a)
   }
 
-instance Monad m => Functor (Traced m) where
+instance (Monad m) => Functor (Traced m) where
   fmap f (Traced m d) = Traced (fmap f m) (fmap (fmap f) d)
 
-instance Monad m => Applicative (Traced m) where
+instance (Monad m) => Applicative (Traced m) where
   pure x = Traced (pure x) (pure (pure x))
   (Traced mf df) <*> (Traced mx dx) = Traced (mf <*> mx) (liftA2 (<*>) df dx)
 
-instance Monad m => Monad (Traced m) where
+instance (Monad m) => Monad (Traced m) where
   (Traced mx dx) >>= f = Traced my dy
     where
       my = mx >>= model . f
@@ -61,23 +61,23 @@ instance Monad m => Monad (Traced m) where
 instance MonadTrans Traced where
   lift m = Traced (lift $ lift m) (fmap pure m)
 
-instance MonadDistribution m => MonadDistribution (Traced m) where
+instance (MonadDistribution m) => MonadDistribution (Traced m) where
   random = Traced random (fmap singleton random)
 
-instance MonadFactor m => MonadFactor (Traced m) where
+instance (MonadFactor m) => MonadFactor (Traced m) where
   score w = Traced (score w) (score w >> pure (scored w))
 
-instance MonadMeasure m => MonadMeasure (Traced m)
+instance (MonadMeasure m) => MonadMeasure (Traced m)
 
 hoist :: (forall x. m x -> m x) -> Traced m a -> Traced m a
 hoist f (Traced m d) = Traced m (f d)
 
 -- | Discard the trace and supporting infrastructure.
-marginal :: Monad m => Traced m a -> m a
+marginal :: (Monad m) => Traced m a -> m a
 marginal (Traced _ d) = fmap output d
 
 -- | A single step of the Trace Metropolis-Hastings algorithm.
-mhStep :: MonadDistribution m => Traced m a -> Traced m a
+mhStep :: (MonadDistribution m) => Traced m a -> Traced m a
 mhStep (Traced m d) = Traced m d'
   where
     d' = d >>= mhTransFree m
@@ -111,7 +111,7 @@ mhStep (Traced m d) = Traced m d'
 -- [True,True,True]
 --
 -- Of course, it will need to be run more than twice to get a reasonable estimate.
-mh :: MonadDistribution m => Int -> Traced m a -> m [a]
+mh :: (MonadDistribution m) => Int -> Traced m a -> m [a]
 mh n (Traced m d) = fmap (map output . NE.toList) (f n)
   where
     f k

--- a/src/Control/Monad/Bayes/Weighted.hs
+++ b/src/Control/Monad/Bayes/Weighted.hs
@@ -39,10 +39,10 @@ newtype Weighted m a = Weighted (StateT (Log Double) m a)
   -- StateT is more efficient than WriterT
   deriving newtype (Functor, Applicative, Monad, MonadIO, MonadTrans, MonadDistribution)
 
-instance Monad m => MonadFactor (Weighted m) where
+instance (Monad m) => MonadFactor (Weighted m) where
   score w = Weighted (modify (* w))
 
-instance MonadDistribution m => MonadMeasure (Weighted m)
+instance (MonadDistribution m) => MonadMeasure (Weighted m)
 
 -- | Obtain an explicit value of the likelihood for a given value.
 weighted, runWeighted :: Weighted m a -> m (a, Log Double)
@@ -52,11 +52,11 @@ runWeighted = weighted
 -- | Compute the sample and discard the weight.
 --
 -- This operation introduces bias.
-unweighted :: Functor m => Weighted m a -> m a
+unweighted :: (Functor m) => Weighted m a -> m a
 unweighted = fmap fst . weighted
 
 -- | Compute the weight and discard the sample.
-extractWeight :: Functor m => Weighted m a -> m (Log Double)
+extractWeight :: (Functor m) => Weighted m a -> m (Log Double)
 extractWeight = fmap snd . weighted
 
 -- | Embed a random variable with explicitly given likelihood.
@@ -69,7 +69,7 @@ withWeight m = Weighted $ do
   return x
 
 -- | Use the weight as a factor in the transformed monad.
-applyWeight :: MonadFactor m => Weighted m a -> m a
+applyWeight :: (MonadFactor m) => Weighted m a -> m a
 applyWeight m = do
   (x, w) <- weighted m
   factor w

--- a/src/Math/Integrators/StormerVerlet.hs
+++ b/src/Math/Integrators/StormerVerlet.hs
@@ -53,7 +53,7 @@ stormerVerlet2H hh nablaQ nablaP prev =
 -- of solutions corrensdonded to times that was requested.
 -- It takes Vector of time points as a parameter and returns a vector of results
 integrateV ::
-  PrimMonad m =>
+  (PrimMonad m) =>
   -- | Internal integrator
   Integrator a ->
   -- | initial  value

--- a/test/TestAdvanced.hs
+++ b/test/TestAdvanced.hs
@@ -15,7 +15,7 @@ import Control.Monad.Bayes.Sampler.Strict
 mcmcConfig :: MCMCConfig
 mcmcConfig = MCMCConfig {numMCMCSteps = 0, numBurnIn = 0, proposal = SingleSiteMH}
 
-smcConfig :: MonadDistribution m => SMCConfig m
+smcConfig :: (MonadDistribution m) => SMCConfig m
 smcConfig = SMCConfig {numSteps = 0, numParticles = 1000, resampler = resampleMultinomial}
 
 passed1, passed2, passed3, passed4, passed5, passed6, passed7 :: IO Bool

--- a/test/TestEnumerator.hs
+++ b/test/TestEnumerator.hs
@@ -15,13 +15,13 @@ import Data.Vector qualified as V
 import Numeric.Log (Log (ln))
 import Sprinkler (hard, soft)
 
-unnorm :: MonadDistribution m => m Int
+unnorm :: (MonadDistribution m) => m Int
 unnorm = categorical $ V.fromList [0.5, 0.8]
 
 passed1 :: Bool
 passed1 = (exp . ln) (evidence unnorm) ~== 1
 
-agg :: MonadDistribution m => m Int
+agg :: (MonadDistribution m) => m Int
 agg = do
   x <- uniformD [0, 1]
   y <- uniformD [2, 1]

--- a/test/TestInference.hs
+++ b/test/TestInference.hs
@@ -29,7 +29,7 @@ import Numeric.Log (Log)
 import Sprinkler (soft)
 import System.Random.Stateful (IOGenM, StdGen)
 
-sprinkler :: MonadMeasure m => m Bool
+sprinkler :: (MonadMeasure m) => m Bool
 sprinkler = Sprinkler.soft
 
 -- | Count the number of particles produced by SMC

--- a/test/TestIntegrator.hs
+++ b/test/TestIntegrator.hs
@@ -32,7 +32,7 @@ normalVariance mean std = variance (normal mean std)
 volumeIsOne :: [Double] -> Bool
 volumeIsOne = (~== 1.0) . volume . uniformD
 
-agg :: MonadDistribution m => m Int
+agg :: (MonadDistribution m) => m Int
 agg = do
   x <- uniformD [0, 1]
   y <- uniformD [2, 1]
@@ -141,7 +141,7 @@ passed14 =
       quadrature = expectation $ normalize $ model1
    in abs (sample - quadrature) < 0.01
 
-model1 :: MonadMeasure m => m Double
+model1 :: (MonadMeasure m) => m Double
 model1 = do
   x <- random
   y <- random

--- a/test/TestPopulation.hs
+++ b/test/TestPopulation.hs
@@ -15,7 +15,7 @@ import Control.Monad.Bayes.Sampler.Strict (sampleIOfixed)
 import Data.AEq (AEq ((~==)))
 import Sprinkler (soft)
 
-weightedSampleSize :: MonadDistribution m => Population m a -> m Int
+weightedSampleSize :: (MonadDistribution m) => Population m a -> m Int
 weightedSampleSize = fmap length . population
 
 popSize :: IO Int
@@ -26,7 +26,7 @@ manySize :: IO Int
 manySize =
   sampleIOfixed (weightedSampleSize $ spawn 5 >> sprinkler >> spawn 3)
 
-sprinkler :: MonadMeasure m => m Bool
+sprinkler :: (MonadMeasure m) => m Bool
 sprinkler = Sprinkler.soft
 
 sprinklerExact :: [(Bool, Double)]

--- a/test/TestSequential.hs
+++ b/test/TestSequential.hs
@@ -10,7 +10,7 @@ import Control.Monad.Bayes.Sequential.Coroutine (advance, finish, finished)
 import Data.AEq (AEq ((~==)))
 import Sprinkler (soft)
 
-twoSync :: MonadMeasure m => m Int
+twoSync :: (MonadMeasure m) => m Int
 twoSync = do
   x <- uniformD [0, 1]
   factor (fromIntegral x)
@@ -18,7 +18,7 @@ twoSync = do
   factor (fromIntegral y)
   return (x + y)
 
-finishedTwoSync :: MonadMeasure m => Int -> m Bool
+finishedTwoSync :: (MonadMeasure m) => Int -> m Bool
 finishedTwoSync n = finished (run n twoSync)
   where
     run 0 d = d
@@ -30,7 +30,7 @@ checkTwoSync 1 = mass (finishedTwoSync 1) False ~== 1
 checkTwoSync 2 = mass (finishedTwoSync 2) True ~== 1
 checkTwoSync _ = error "Unexpected argument"
 
-sprinkler :: MonadMeasure m => m Bool
+sprinkler :: (MonadMeasure m) => m Bool
 sprinkler = Sprinkler.soft
 
 checkPreserve :: Bool
@@ -42,7 +42,7 @@ pFinished 1 = 0.9988062077198566
 pFinished 2 = 1
 pFinished _ = error "Unexpected argument"
 
-isFinished :: MonadMeasure m => Int -> m Bool
+isFinished :: (MonadMeasure m) => Int -> m Bool
 isFinished n = finished (run n sprinkler)
   where
     run 0 d = d

--- a/test/TestWeighted.hs
+++ b/test/TestWeighted.hs
@@ -14,7 +14,7 @@ import Data.AEq (AEq ((~==)))
 import Data.Bifunctor (second)
 import Numeric.Log (Log (Exp, ln))
 
-model :: MonadMeasure m => m (Int, Double)
+model :: (MonadMeasure m) => m (Int, Double)
 model = do
   n <- uniformD [0, 1, 2]
   unless (n == 0) (factor 0.5)
@@ -22,7 +22,7 @@ model = do
   when (n == 2) (factor $ (Exp . log) (x * x))
   return (n, x)
 
-result :: MonadDistribution m => m ((Int, Double), Double)
+result :: (MonadDistribution m) => m ((Int, Double), Double)
 result = second (exp . ln) <$> weighted model
 
 passed :: IO Bool


### PR DESCRIPTION
Recently, a CI run failed because the ormolu version has since updated, and changed some conventions: https://github.com/tweag/monad-bayes/actions/runs/6050563556/job/16420144015 It was necessary to re-format plenty of files.

@reubenharry @idontgetoutmuch can you review & approve?

