### PR TITLE
Showing that random-fu is x4 faster than mwc and thus monad-bayes

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,2 +1,3 @@
+use nix
 # Make sure you have direnv >= 2.30
-use flake --extra-experimental-features nix-command --extra-experimental-features flakes
+# use flake --extra-experimental-features nix-command --extra-experimental-features flakes

--- a/default.nix
+++ b/default.nix
@@ -1,14 +1,49 @@
-(
-  import
-  (
-    let
-      lock = builtins.fromJSON (builtins.readFile ./flake.lock);
-    in
-      fetchTarball {
-        url = "https://github.com/edolstra/flake-compat/archive/${lock.nodes.flake-compat.locked.rev}.tar.gz";
-        sha256 = lock.nodes.flake-compat.locked.narHash;
-      }
-  )
-  {src = ./.;}
-)
-.defaultNix
+{ mkDerivation, abstract-par, base, brick, containers, criterion
+, directory, foldl, free, histogram-fill, hspec, ieee754
+, integration, lens, lib, linear, log-domain, math-functions
+, matrix, monad-coroutine, monad-extras, mtl, mwc-random
+, optparse-applicative, pipes, pretty-simple, primitive, process
+, QuickCheck, random, safe, scientific, statistics, text, time
+, transformers, typed-process, vector, vty
+}:
+mkDerivation {
+  pname = "monad-bayes";
+  version = "1.2.0";
+  src = ./.;
+  isLibrary = true;
+  isExecutable = true;
+  libraryHaskellDepends = [
+    base brick containers foldl free histogram-fill ieee754 integration
+    lens linear log-domain math-functions matrix monad-coroutine
+    monad-extras mtl mwc-random pipes pretty-simple primitive random
+    safe scientific statistics text vector vty
+  ];
+  executableHaskellDepends = [
+    abstract-par base brick containers criterion directory foldl free
+    histogram-fill hspec ieee754 integration lens linear log-domain
+    math-functions matrix monad-coroutine monad-extras mtl mwc-random
+    optparse-applicative pipes pretty-simple primitive process
+    QuickCheck random safe scientific statistics text time transformers
+    typed-process vector vty
+  ];
+  testHaskellDepends = [
+    abstract-par base brick containers criterion directory foldl free
+    histogram-fill hspec ieee754 integration lens linear log-domain
+    math-functions matrix monad-coroutine monad-extras mtl mwc-random
+    optparse-applicative pipes pretty-simple primitive process
+    QuickCheck random safe scientific statistics text time transformers
+    typed-process vector vty
+  ];
+  benchmarkHaskellDepends = [
+    abstract-par base brick containers criterion directory foldl free
+    histogram-fill hspec ieee754 integration lens linear log-domain
+    math-functions matrix monad-coroutine monad-extras mtl mwc-random
+    optparse-applicative pipes pretty-simple primitive process
+    QuickCheck random safe scientific statistics text time transformers
+    typed-process vector vty
+  ];
+  homepage = "http://github.com/tweag/monad-bayes#readme";
+  description = "A library for probabilistic programming";
+  license = lib.licenses.mit;
+  mainProgram = "example";
+}

--- a/samplePerformance.hs
+++ b/samplePerformance.hs
@@ -1,0 +1,50 @@
+{-# OPTIONS_GHC -Wall              #-}
+{-# OPTIONS_GHC -Wno-type-defaults #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+-- From random
+import           System.Random.Stateful
+
+-- From mwc-random
+import qualified System.Random.MWC.Distributions as MWC
+
+-- From random-fu
+import Data.Random
+
+-- From monad-bayes
+import qualified Control.Monad.Bayes.Class as MonadBayes
+import Control.Monad.Bayes.Sampler.Strict
+
+import Criterion.Main
+import Control.DeepSeq (NFData)
+import Foreign
+
+
+main :: IO ()
+main = do
+    stdGen <- newIOGenM =<< newStdGen
+    defaultMain
+        [ bgroup "dists"
+            [ bgroup "StdGen" (dists (stdGen :: (IOGenM StdGen)))
+            ]
+        ]
+
+dists :: StatefulGen g IO => g -> [Benchmark]
+dists gen =
+    [ doubleSuite gen "stdNormal" (Normal 0.0 1.0)
+    ]
+
+doubleSuite :: (Distribution d Double, StatefulGen g IO) => g -> String -> d Double -> Benchmark
+doubleSuite = suite
+
+suite :: (Storable t, Num t, Distribution d t, NFData t, StatefulGen g IO) => g -> String -> d t -> Benchmark
+suite gen name var = bgroup name
+    [ bench "single sample" $ nfIO $ do
+        sampleFrom gen var
+    , bench "single sample MWC" $ nfIO $ do
+        MWC.normal 0.0 1.0 gen
+    , bench "single sample monad bayes" $ nfIO $ do
+        sampleWith (MonadBayes.normal 0.0 1.0) gen
+    ]
+

--- a/shell.nix
+++ b/shell.nix
@@ -1,14 +1,54 @@
-(
-  import
-  (
-    let
-      lock = builtins.fromJSON (builtins.readFile ./flake.lock);
-    in
-      fetchTarball {
-        url = "https://github.com/edolstra/flake-compat/archive/${lock.nodes.flake-compat.locked.rev}.tar.gz";
-        sha256 = lock.nodes.flake-compat.locked.narHash;
-      }
-  )
-  {src = ./.;}
-)
-.shellNix
+let
+
+myHaskellPackageOverlay = self: super: {
+  myHaskellPackages = super.haskellPackages.override {
+    overrides = hself: hsuper: rec {
+      random-fu = super.haskell.lib.dontCheck (hself.callCabal2nixWithOptions "random-fu" (builtins.fetchGit {
+        url = "https://github.com/haskell-numerics/random-fu";
+        rev = "b5cf96c6d904faa6adcf010a88f3ee117b289a4f";
+      }) "--subpath random-fu" { });
+      rvar = super.haskell.lib.dontCheck (hself.callCabal2nixWithOptions "rvar" (builtins.fetchGit {
+        url = "https://github.com/haskell-numerics/random-fu";
+        rev = "b5cf96c6d904faa6adcf010a88f3ee117b289a4f";
+      }) "--subpath rvar" { });
+      monad-bayes = super.haskell.lib.dontCheck (
+        super.haskell.lib.doJailbreak (
+          super.haskell.lib.disableLibraryProfiling (hself.callPackage  ./. { })
+        )
+      );
+   };
+  };
+};
+
+in
+
+{ nixpkgs ? import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/nixpkgs-23.05-darwin.tar.gz")
+  {
+    overlays = [ myHaskellPackageOverlay ];
+    config.allowBroken = true;
+  }
+}:
+
+let
+
+  pkgs = nixpkgs;
+
+  haskellDeps = ps: with ps; [
+    base criterion deepseq
+    mersenne-random-pure64
+    monad-bayes
+    MonadRandom mtl mwc-random random random-fu stateref vector
+  ];
+
+in
+
+pkgs.stdenv.mkDerivation {
+  name = "simple-shell";
+
+  buildInputs = [
+    pkgs.cabal-install
+    pkgs.cabal2nix
+    (pkgs.myHaskellPackages.ghcWithPackages haskellDeps)
+    pkgs.darwin.apple_sdk.frameworks.Cocoa
+  ];
+}


### PR DESCRIPTION
```
ghc samplePerformance.hs 
[1 of 1] Compiling Main             ( samplePerformance.hs, samplePerformance.o )
Linking samplePerformance ...

./samplePerformance 
benchmarking dists/StdGen/stdNormal/single sample
time                 45.20 ns   (45.16 ns .. 45.25 ns)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 45.28 ns   (45.22 ns .. 45.41 ns)
std dev              304.5 ps   (173.5 ps .. 545.5 ps)

benchmarking dists/StdGen/stdNormal/single sample MWC
time                 157.0 ns   (156.9 ns .. 157.2 ns)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 157.0 ns   (156.9 ns .. 157.3 ns)
std dev              600.7 ps   (338.0 ps .. 990.2 ps)

benchmarking dists/StdGen/stdNormal/single sample monad bayes
time                 157.2 ns   (156.9 ns .. 157.6 ns)
                     0.999 R²   (0.998 R² .. 1.000 R²)
mean                 158.5 ns   (157.1 ns .. 163.6 ns)
std dev              8.239 ns   (1.448 ns .. 17.33 ns)
variance introduced by outliers: 71% (severely inflated)
```