### PR TITLE
Add fixtures to datadir

### DIFF
--- a/monad-bayes.cabal
+++ b/monad-bayes.cabal
@@ -25,6 +25,8 @@ extra-source-files:
   CHANGELOG.md
   README.md
 
+data-files:         test/fixtures/*.txt
+
 source-repository head
   type:     git
   location: https://github.com/tweag/monad-bayes.git
@@ -77,6 +79,9 @@ common test-deps
     , time                  >=1.9    && <1.13
     , transformers          ^>=0.5.6
     , typed-process         ^>=0.2
+
+  autogen-modules: Paths_monad_bayes
+  other-modules:   Paths_monad_bayes
 
 library
   import:             deps

--- a/test/TestBenchmarks.hs
+++ b/test/TestBenchmarks.hs
@@ -3,12 +3,13 @@ module TestBenchmarks where
 import Control.Monad (forM_)
 import Data.Maybe (fromJust)
 import Helper
+import Paths_monad_bayes (getDataDir)
 import System.IO (readFile')
 import System.IO.Error (catchIOError, isDoesNotExistError)
 import Test.Hspec
 
 fixtureToFilename :: Model -> Alg -> String
-fixtureToFilename model alg = fromJust (serializeModel model) ++ "-" ++ show alg ++ ".txt"
+fixtureToFilename model alg = "/test/fixtures/" ++ fromJust (serializeModel model) ++ "-" ++ show alg ++ ".txt"
 
 models :: [Model]
 models = [LR 10, HMM 10, LDA (5, 10)]
@@ -21,7 +22,8 @@ test = describe "Benchmarks" $ forM_ models $ \model -> forM_ algs $ testFixture
 
 testFixture :: Model -> Alg -> SpecWith ()
 testFixture model alg = do
-  let filename = "test/fixtures/" ++ fixtureToFilename model alg
+  dataDir <- runIO getDataDir
+  let filename = dataDir <> fixtureToFilename model alg
   it ("should agree with the fixture " ++ filename) $ do
     fixture <- catchIOError (readFile' filename) $ \e ->
       if isDoesNotExistError e

--- a/test/TestSSMFixtures.hs
+++ b/test/TestSSMFixtures.hs
@@ -3,16 +3,18 @@ module TestSSMFixtures where
 import Control.Monad.Bayes.Sampler.Strict (sampleIOfixed)
 import NonlinearSSM
 import NonlinearSSM.Algorithms
+import Paths_monad_bayes (getDataDir)
 import System.IO (readFile')
 import System.IO.Error (catchIOError, isDoesNotExistError)
 import Test.Hspec
 
 fixtureToFilename :: Alg -> FilePath
-fixtureToFilename alg = "test/fixtures/SSM-" ++ show alg ++ ".txt"
+fixtureToFilename alg = "/test/fixtures/SSM-" ++ show alg ++ ".txt"
 
 testFixture :: Alg -> SpecWith ()
 testFixture alg = do
-  let filename = fixtureToFilename alg
+  dataDir <- runIO getDataDir
+  let filename = dataDir <> fixtureToFilename alg
   it ("should agree with the fixture " ++ filename) $ do
     ys <- sampleIOfixed $ generateData t
     fixture <- catchIOError (readFile' filename) $ \e ->


### PR DESCRIPTION
In https://github.com/tweag/monad-bayes/pull/256 I introduced fixture test. See https://github.com/NixOS/nixpkgs/pull/262645#issuecomment-1785380903, the fixture tests don't work if the fixtures are not added to the cabal package. I did this here.

@idontgetoutmuch @reubenharry can you review and approve?