### PR TITLE
Bump mtl -> 2.3, transformers -> 0.6

### DIFF
--- a/monad-bayes.cabal
+++ b/monad-bayes.cabal
@@ -53,7 +53,7 @@ common deps
     , matrix           ^>=0.3
     , monad-coroutine  ^>=0.9.0
     , monad-extras     ^>=0.6
-    , mtl              ^>=2.2.2
+    , mtl              >=2.2     && <2.4
     , mwc-random       >=0.13.6  && <0.16
     , pipes            ^>=4.3
     , pretty-simple    ^>=4.1
@@ -63,21 +63,21 @@ common deps
     , scientific       ^>=0.3
     , statistics       >=0.14.0  && <0.17
     , text             >=1.2     && <2.1
+    , transformers     >=0.5.6   && <0.7
     , vector           >=0.12.0  && <0.14
     , vty              ^>=5.38
 
 common test-deps
   build-depends:
     , abstract-par          ^>=0.3
-    , criterion             >=1.5    && <1.7
+    , criterion             >=1.5   && <1.7
     , directory             ^>=1.3
     , hspec                 ^>=2.11
     , monad-bayes
-    , optparse-applicative  >=0.17   && <0.19
+    , optparse-applicative  >=0.17  && <0.19
     , process               ^>=1.6
     , QuickCheck            ^>=2.14
-    , time                  >=1.9    && <1.13
-    , transformers          ^>=0.5.6
+    , time                  >=1.9   && <1.13
     , typed-process         ^>=0.2
 
   autogen-modules: Paths_monad_bayes

--- a/src/Control/Applicative/List.hs
+++ b/src/Control/Applicative/List.hs
@@ -1,0 +1,23 @@
+{-# LANGUAGE StandaloneDeriving #-}
+
+module Control.Applicative.List where
+
+-- base
+import Control.Applicative
+import Data.Functor.Compose
+
+-- * Applicative ListT
+
+-- | _Applicative_ transformer adding a list/nondeterminism/choice effect.
+--   It is not a valid monad transformer, but it is a valid 'Applicative'.
+newtype ListT m a = ListT {getListT :: Compose m [] a}
+  deriving newtype (Functor, Applicative, Alternative)
+
+listT :: m [a] -> ListT m a
+listT = ListT . Compose
+
+lift :: (Functor m) => m a -> ListT m a
+lift = ListT . Compose . fmap pure
+
+runListT :: ListT m a -> m [a]
+runListT = getCompose . getListT

--- a/src/Control/Monad/Bayes/Class.hs
+++ b/src/Control/Monad/Bayes/Class.hs
@@ -77,11 +77,11 @@ where
 import Control.Arrow (Arrow (second))
 import Control.Monad (replicateM, when)
 import Control.Monad.Cont (ContT)
-import Control.Monad.Except (ExceptT, lift)
+import Control.Monad.Except (ExceptT)
 import Control.Monad.Identity (IdentityT)
-import Control.Monad.List (ListT)
 import Control.Monad.Reader (ReaderT)
 import Control.Monad.State (StateT)
+import Control.Monad.Trans.Class (lift)
 import Control.Monad.Writer (WriterT)
 import Data.Histogram qualified as H
 import Data.Histogram.Fill qualified as H
@@ -389,16 +389,6 @@ instance (MonadFactor m) => MonadFactor (StateT s m) where
   score = lift . score
 
 instance (MonadMeasure m) => MonadMeasure (StateT s m)
-
-instance (MonadDistribution m) => MonadDistribution (ListT m) where
-  random = lift random
-  bernoulli = lift . bernoulli
-  categorical = lift . categorical
-
-instance (MonadFactor m) => MonadFactor (ListT m) where
-  score = lift . score
-
-instance (MonadMeasure m) => MonadMeasure (ListT m)
 
 instance (MonadDistribution m) => MonadDistribution (ContT r m) where
   random = lift random

--- a/test/TestWeighted.hs
+++ b/test/TestWeighted.hs
@@ -2,6 +2,7 @@
 
 module TestWeighted (check, passed, result, model) where
 
+import Control.Monad (unless, when)
 import Control.Monad.Bayes.Class
   ( MonadDistribution (normal, uniformD),
     MonadMeasure,
@@ -9,7 +10,6 @@ import Control.Monad.Bayes.Class
   )
 import Control.Monad.Bayes.Sampler.Strict (sampleIOfixed)
 import Control.Monad.Bayes.Weighted (runWeightedT)
-import Control.Monad.State (unless, when)
 import Data.AEq (AEq ((~==)))
 import Data.Bifunctor (second)
 import Numeric.Log (Log (Exp, ln))


### PR DESCRIPTION
This is the minimal change necessary to support the newer versions of `mtl` and `transformers`, both needed for #294. This doesn't solve #245 yet because it just copies the old `ListT` implementation, which is still invalid.