### PR TITLE
Bump version to 1.3.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.3.0.2
+
+- Relaxed some version bounds
+
 # 1.3.0.1
 
 - Support for GHC 9.8

--- a/monad-bayes.cabal
+++ b/monad-bayes.cabal
@@ -1,6 +1,6 @@
 cabal-version:   2.2
 name:            monad-bayes
-version:         1.3.0.1
+version:         1.3.0.2
 license:         MIT
 license-file:    LICENSE.md
 copyright:       2015-2020 Adam Scibior


### PR DESCRIPTION
I forgot to push the version bump in https://github.com/tweag/monad-bayes/pull/345. Here it is :) CC @reubenharry @idontgetoutmuch 