### PR TITLE
Build aarch64-linux in CI, pin down the fixture failures, and clean up the flake

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -27,6 +27,12 @@ jobs:
         include:
           - os: ubuntu-latest
             system: x86_64-linux
+          # aarch64-linux told us that the fixture test failures are about the
+          # architecture and not about Apple's libm, see the `modifier` in
+          # flake.nix. Keep building it so the platform nixpkgs ships from stays
+          # green, and so we notice when the tests can be turned back on there.
+          - os: ubuntu-24.04-arm
+            system: aarch64-linux
           # The macos-latest runners are arm64, and nixpkgs 26.11 dropped
           # x86_64-darwin altogether.
           - os: macos-latest

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -78,19 +78,13 @@ jobs:
       - name: Development environment (package only)
         run: nix --print-build-logs develop .#packages.${{ matrix.system }}.monad-bayes-per-ghc.${{ matrix.ghc }} --command echo Ready
 
+  # Only on x86_64-linux: this job asserts that the committed *.html matches what
+  # regenerating the notebooks produces, and that output is platform dependent.
   notebooks:
     needs:
       - build
       - build-all-ghcs
-    strategy:
-      matrix:
-        include:
-          - os: ubuntu-latest
-            system: x86_64-linux
-          # The Jupyter kernel is only tested on Linux so far
-          # - os: macos-latest
-          #   system: x86_64-darwin
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
       - name: Setup Nix Environment

--- a/flake.nix
+++ b/flake.nix
@@ -35,11 +35,11 @@
     } @ inputs:
     flake-utils.lib.eachSystem
       [
-        # Tier 1 - Tested in CI
+        # All of these are built in CI, see .github/workflows/nix.yml. The test
+        # suite only runs on x86_64 though, see the `modifier` below.
         flake-utils.lib.system.x86_64-linux
-        flake-utils.lib.system.aarch64-darwin
-        # Tier 2 - Not tested in CI (at least for now)
         flake-utils.lib.system.aarch64-linux
+        flake-utils.lib.system.aarch64-darwin
         # Note: no x86_64-darwin. nixpkgs 26.11 dropped support for it, and
         # importing nixpkgs for that system now throws rather than merely warns.
         # See https://github.com/NixOS/nixpkgs/pull/535508 and
@@ -100,11 +100,21 @@
             root = src;
             cabal2nixOptions = "--benchmark -fdev";
 
-            # https://github.com/tweag/monad-bayes/pull/256: Don't run tests on Mac because of machine precision issues
-            modifier = drv:
-              if system == "x86_64-linux"
-              then drv
-              else pkgs.haskell.lib.dontCheck drv;
+            # Only run the tests on x86_64, they fail on aarch64 because of machine
+            # precision issues: the fixture tests compare `show`n `Double`s against
+            # committed fixtures that were generated on x86_64, and IEEE 754 only
+            # mandates correct rounding for the basic operations and `sqrt`, not for
+            # `log`, `exp`, `log1p` or `**`. Those come from the platform's libm and
+            # differ in the last ulp.
+            # It is the architecture, not Apple's libm: five of the 45 examples fail
+            # the same way on aarch64-linux against glibc, which is why we build
+            # there in CI. See https://github.com/tweag/monad-bayes/pull/256,
+            # https://github.com/tweag/monad-bayes/pull/389 and
+            # https://github.com/tweag/monad-bayes/issues/368.
+            modifier =
+              if pkgs.stdenv.hostPlatform.isx86_64
+              then lib.id
+              else pkgs.haskell.lib.dontCheck;
             overrides = haskellOverrides;
           };
 

--- a/flake.nix
+++ b/flake.nix
@@ -28,11 +28,12 @@
   outputs =
     { self
     , nixpkgs
-    , flake-compat
+    , # Not used here, but default.nix and shell.nix read it out of flake.lock
+      flake-compat
     , flake-utils
     , pre-commit-hooks
     ,
-    } @ inputs:
+    }:
     flake-utils.lib.eachSystem
       [
         # All of these are built in CI, see .github/workflows/nix.yml. The test
@@ -52,17 +53,15 @@
           inherit (nixpkgs) lib;
           pkgs = import nixpkgs {
             inherit system;
-            config.allowBroken = true;
           };
 
-          warnToUpdateNix = pkgs.lib.warn "Consider updating to Nix > 2.7 to remove this warning!";
           src = lib.sourceByRegex self [
             "^benchmark.*$"
             "^models.*$"
-            "^monad-bayes\.cabal$"
+            "^monad-bayes\\.cabal$"
             "^src.*$"
             "^test.*$"
-            "^.*\.md"
+            "^.*\\.md"
           ];
 
           # Always keep this up to date with the tested-with section in monad-bayes.cabal!
@@ -79,19 +78,14 @@
           allHaskellPackages = lib.filterAttrs (ghcVersion: _: builtins.elem ghcVersion ghcs) (pkgs.haskell.packages // { default = pkgs.haskellPackages; });
 
           # Please check after flake.lock updates whether some of these overrides can be removed
-          haskellOverrides = self: super:
-            with pkgs.haskell.lib;
-            {
-              # nixpkgs still ships brick 2.9, but we need >= 2.10
-              brick = super.callHackageDirect {
-                pkg = "brick";
-                ver = "2.10";
-                sha256 = "sha256-m1PvPySOuTZbcnCm4j7M7AihK0w8OGKumyRR3jU5nfw=";
-              } { };
-            }
-            // lib.optionalAttrs (lib.versionAtLeast super.ghc.version "9.10") {
-              microstache = doJailbreak super.microstache;
-            };
+          haskellOverrides = self: super: {
+            # nixpkgs still ships brick 2.9, but we need >= 2.10
+            brick = super.callHackageDirect {
+              pkg = "brick";
+              ver = "2.10";
+              sha256 = "sha256-m1PvPySOuTZbcnCm4j7M7AihK0w8OGKumyRR3jU5nfw=";
+            } { };
+          };
 
           haskellPackagesFor = haskellPackages: haskellPackages.extend haskellOverrides;
 
@@ -167,7 +161,6 @@
             ];
           };
 
-
           pre-commit = pre-commit-hooks.lib.${system}.run {
             inherit src;
             hooks = {
@@ -176,7 +169,7 @@
               ormolu.enable = true;
             };
           };
-          devShellFor = ghcVersion: haskellPackages: addJupyter: haskellPackages.shellFor {
+          devShellFor = haskellPackages: addJupyter: haskellPackages.shellFor {
             packages = hps: [
               (monad-bayes-for haskellPackages)
             ];
@@ -190,9 +183,10 @@
             # Cabal-syntax from source, which fails on GHC 9.4.
             ++ [ pkgs.cabal-install ]
             ++ lib.optional addJupyter jupyterEnvironment
-            ++ (with haskellPackages; [
-              haskell-language-server
-            ]);
+            # haskell-language-server dropped GHC 9.4 in 2.12.0.0, and nixpkgs
+            # `throw`s on it rather than marking it broken.
+            ++ lib.optional (lib.versionAtLeast haskellPackages.ghc.version "9.6")
+              haskellPackages.haskell-language-server;
           };
         in
         rec {
@@ -203,13 +197,10 @@
           checks = { inherit monad-bayes pre-commit; };
           devShells = lib.concatMapAttrs
             (ghcVersion: haskellPackages: {
-              "${ghcVersion}" = devShellFor ghcVersion haskellPackages false;
-              "${ghcVersion}-jupyter" = devShellFor ghcVersion haskellPackages true;
+              "${ghcVersion}" = devShellFor haskellPackages false;
+              "${ghcVersion}-jupyter" = devShellFor haskellPackages true;
             })
             allHaskellPackages;
-          # Needed for backwards compatibility with Nix versions <2.8
-          defaultPackage = warnToUpdateNix packages.default;
-          devShell = warnToUpdateNix devShells.default;
           formatter = pkgs.nixpkgs-fmt;
         }
       );


### PR DESCRIPTION
Stacked on #388 — review that one first, this PR's base is `flake-update-fixes`.

## Build aarch64-linux in CI, and find out why the fixture tests fail

The Darwin test skip from #256 was written as "anything that isn't `x86_64-linux`":

```nix
modifier = drv:
  if system == "x86_64-linux"
  then drv
  else pkgs.haskell.lib.dontCheck drv;
```

so it silently disabled the test suite on `aarch64-linux` as well. That matters,
because it is exactly the configuration that tells us *why* the fixtures disagree
on Darwin. This PR adds an `aarch64-linux` job to CI on a `ubuntu-24.04-arm`
runner (free and unlimited on public repos) and runs the tests there.

### The hypothesis

The fixture tests in `test/TestSSMFixtures.hs` and `test/TestBenchmarks.hs` compare
`show`n `Double`s against committed fixtures, so a single ulp anywhere fails them.
Of everything in the sampling path:

* `mwc-random`'s core is integer arithmetic — bit-identical everywhere.
* `+ - * /` and `sqrt` are correctly rounded per IEEE 754 — bit-identical everywhere.
* `math-functions`' special functions are pure-Haskell rational/Chebyshev
  approximations — bit-identical everywhere.
* `log`, `exp`, `log1p`, `expm1` and `**` are foreign calls into the platform's
  libm, and IEEE 754 does *not* require these to be correctly rounded.

So the hypothesis was that the divergence is glibc (which the fixtures were
generated against) versus Apple's libm, not Intel versus ARM. `aarch64-linux`
holds the libm fixed and varies the architecture, which discriminates between
the two: if it passes, the cause is the libm; if it fails, the cause is
architectural and the reasoning above is wrong.

### The answer: it is the architecture

It fails. [Run 30532566710](https://github.com/tweag/monad-bayes/actions/runs/30532566710/job/90838226558?pr=389),
`aarch64-linux`, glibc, 45 examples, 5 failures:

```
1) Benchmarks       LR10-SMC
2) TestSSMFixtures  SSM-RMSMC
3) TestSSMFixtures  SSM-RMSMCDynamic
4) TestSSMFixtures  SSM-RMSMCBasic
5) TestSSMFixtures  SSM-SMC2
```

and the deviations are exactly one ulp in a single element, e.g. in `SSM-RMSMCBasic`:

```
expected: -362.48592096242163
 but got: -362.4859209624216
```

So Apple's libm is not the cause, glibc on aarch64 does the same thing, and no
amount of changing the Darwin architecture would have helped. Correspondingly
this PR now:

* keeps the `aarch64-linux` job, because it builds the platform nixpkgs ships
  aarch64 from (#368) and it is where a fix can be verified without a Mac;
* skips the test suite on **aarch64** rather than on **Darwin**, which is what
  the condition always meant to say;
* records the finding in the comment, instead of the wrong glibc-vs-Apple guess.

The "Find out what is different, and use a type with system-independent
precision" checkbox from #256 is still unchecked, but the first half of it is
now answered.

### Follow-up

Making the tests actually pass on aarch64 means not comparing `show`n `Double`s
any more, as discussed below with @qnikst: serialise the fixtures as JSON and
compare numerically with an epsilon, or wrap the result type in a newtype whose
`Show` rounds to a fixed number of digits. That is a separate PR; #368 tracks it.

## Cleanup

Second commit, no behaviour change intended:

* `config.allowBroken = true` is no longer needed now that we build Jupyter from
  nixpkgs instead of jupyenv. Verified by evaluating every output CI builds
  without it: `monad-bayes`, all five `monad-bayes-per-ghc` entries,
  `jupyterEnvironment`, `pre-commit` and the dev shells.
* `microstache` no longer needs `doJailbreak` on GHC 9.10 or 9.12 — both build
  unpatched straight from the binary cache.
* `defaultPackage`/`devShell` were there for Nix < 2.8, which is over three years
  old. `flake-compat` prefers `packages.default`/`devShells.default` over them
  anyway, so `default.nix` and `shell.nix` keep working.
* `nix develop .#ghc94` was broken: `haskell-language-server` dropped GHC 9.4 in
  2.12.0.0 and nixpkgs `throw`s on it rather than marking it broken. Now only
  added for GHC >= 9.6.
* `"\."` in a Nix string is an ill-defined escape and warns on every evaluation.
* `devShellFor` never used its `ghcVersion` argument.
* The `notebooks` job had a one-entry matrix plus a commented-out `x86_64-darwin`
  entry for a system nixpkgs no longer supports.
